### PR TITLE
fix(referral): Pass referral code through auth flow

### DIFF
--- a/apps/web/src/app/api/auth/connect/route.ts
+++ b/apps/web/src/app/api/auth/connect/route.ts
@@ -8,13 +8,13 @@ import { errorResponse, BadRequestError } from '@/lib/server/errors';
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { walletAddress, signature } = body;
+    const { walletAddress, signature, referralCode } = body;
 
     if (!walletAddress || !signature) {
       throw new BadRequestError('walletAddress and signature are required');
     }
 
-    const result = await AuthService.authenticateWallet(walletAddress, signature);
+    const result = await AuthService.authenticateWallet(walletAddress, signature, referralCode);
 
     return Response.json({ success: true, ...result });
   } catch (error) {

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { useAuthStore } from '@/lib/store';
 import { api } from '@/lib/api';
+import { getStoredReferralCode, clearStoredReferralCode } from '@/lib/hooks/useReferralTracking';
 import bs58 from 'bs58';
 
 const AUTH_MESSAGE = 'Sign this message to authenticate with Trading Fight Club';
@@ -36,11 +37,20 @@ export function useAuth() {
       const signature = await signMessage(message);
       const signatureBase58 = bs58.encode(signature);
 
+      // Get referral code from localStorage (if user came via referral link)
+      const referralCode = getStoredReferralCode() || undefined;
+
       // Send to API - will create account and auto-link Pacifica if available
       const response = await api.connectWallet(
         publicKey.toBase58(),
-        signatureBase58
+        signatureBase58,
+        referralCode
       );
+
+      // Clear referral code after successful registration
+      if (referralCode) {
+        clearStoredReferralCode();
+      }
 
       // Store auth state including Pacifica connection status
       setAuth(response.token, response.user, response.pacificaConnected);

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -52,11 +52,12 @@ async function fetchApi<T>(endpoint: string, options: ApiOptions = {}): Promise<
 
 export async function connectWallet(
   walletAddress: string,
-  signature: string
+  signature: string,
+  referralCode?: string
 ): Promise<{ token: string; user: User; pacificaConnected: boolean }> {
   return fetchApi('/auth/connect', {
     method: 'POST',
-    body: JSON.stringify({ walletAddress, signature }),
+    body: JSON.stringify({ walletAddress, signature, referralCode }),
   });
 }
 


### PR DESCRIPTION
- Add referralCode parameter to connectWallet API function
- Extract referralCode from request body in auth/connect route
- Get stored referral code from localStorage in useAuth hook
- Clear referral code after successful registration

Fixes: referred_by_id was NULL because referral code wasn't being passed