### PR TITLE
feat: add quick positions bar with centralized trading utils

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -980,3 +980,17 @@ input[type="range"]::-moz-range-thumb {
 [data-sonner-toast][data-styled=true] [data-description] {
   color: #c7c7c7 !important;
 }
+
+/* ===========================================================
+   Scrollbar Hide Utility
+   =========================================================== */
+
+/* Completely hide scrollbar while maintaining scroll functionality */
+.scrollbar-hide {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;  /* Chrome, Safari, Opera */
+}

--- a/apps/web/src/components/QuickPositionModal.tsx
+++ b/apps/web/src/components/QuickPositionModal.tsx
@@ -1,0 +1,546 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useCreateMarketOrder, useSetPositionTpSl } from '@/hooks/useOrders';
+import { usePrices } from '@/hooks/usePrices';
+import type { Position } from '@/hooks/usePacificaWebSocket';
+import CloseIcon from '@mui/icons-material/Close';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
+import SwapVertIcon from '@mui/icons-material/SwapVert';
+import {
+  calculateTpPrice,
+  calculateSlPrice,
+  calculatePositionMetrics,
+  roundToLotSize,
+  type PositionInfo,
+  type RawPosition
+} from '@/lib/trading/utils';
+
+interface QuickPositionModalProps {
+  position: Position;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * QuickPositionModal - Quick actions for positions
+ * - Close position (market order)
+ * - Set stop loss
+ * - Set take profit
+ * - Flip position (close and reverse)
+ */
+export function QuickPositionModal({ position, isOpen, onClose }: QuickPositionModalProps) {
+  const { getPrice } = usePrices();
+  const createMarketOrder = useCreateMarketOrder();
+  const setTpSl = useSetPositionTpSl();
+
+  const [activeTab, setActiveTab] = useState<'close' | 'tpsl' | 'flip'>('close');
+  const [closeAmount, setCloseAmount] = useState('100'); // Percentage
+  const [stopLossPrice, setStopLossPrice] = useState('');
+  const [takeProfitPrice, setTakeProfitPrice] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const symbol = position.symbol;
+  const symbolBase = symbol.replace('-USD', '');
+  const priceData = getPrice(`${symbolBase}-USD`);
+  const markPrice = priceData?.price || parseFloat(position.entry_price);
+  const leverage = priceData?.maxLeverage || 10; // Default leverage
+
+  // Use centralized calculation (same as QuickPositionsBar and Terminal)
+  const metrics = calculatePositionMetrics({
+    position,
+    markPrice,
+    leverage,
+  });
+
+  // Extract calculated values
+  const { entryPrice, amount: positionSize, side, margin, unrealizedPnl: pnl, unrealizedPnlPercent: pnlPercent } = metrics;
+  const currentPrice = markPrice;
+  const isLong = side === 'LONG';
+  const isProfitable = pnl >= 0;
+
+  // Get lot size and tick size from price data
+  const lotSize = priceData?.lotSize || 0.00001;
+  const tickSize = priceData?.tickSize || 0.01;
+
+  // Position info for TP/SL calculations (margin-based)
+  const positionInfo: PositionInfo = {
+    side,
+    entryPrice,
+    margin,
+    sizeInToken: positionSize,
+  };
+
+  // Calculate close amount in tokens and round to lot size using centralized function
+  const closePercentage = parseFloat(closeAmount) || 100;
+  const rawCloseAmount = (positionSize * closePercentage) / 100;
+  const closeAmountTokens = parseFloat(roundToLotSize(rawCloseAmount, lotSize));
+
+  // Reset form when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setCloseAmount('100');
+      setStopLossPrice('');
+      setTakeProfitPrice('');
+      setActiveTab('close');
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleClose = async () => {
+    if (isSubmitting) return;
+
+    try {
+      setIsSubmitting(true);
+
+      await createMarketOrder.mutateAsync({
+        symbol: symbol,
+        side: isLong ? 'ask' : 'bid', // Opposite side to close
+        amount: closeAmountTokens.toFixed(8),
+        reduceOnly: true,
+        slippage_percent: '1',
+      });
+
+      onClose();
+    } catch (error) {
+      console.error('Failed to close position:', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSetTpSl = async () => {
+    if (isSubmitting) return;
+
+    try {
+      setIsSubmitting(true);
+
+      const takeProfit = takeProfitPrice
+        ? { stop_price: takeProfitPrice }
+        : null;
+
+      const stopLoss = stopLossPrice
+        ? { stop_price: stopLossPrice }
+        : null;
+
+      await setTpSl.mutateAsync({
+        symbol: symbol,
+        side: isLong ? 'LONG' : 'SHORT',
+        size: position.amount,
+        take_profit: takeProfit,
+        stop_loss: stopLoss,
+      });
+
+      onClose();
+    } catch (error) {
+      console.error('Failed to set TP/SL:', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleFlip = async () => {
+    if (isSubmitting) return;
+
+    try {
+      setIsSubmitting(true);
+
+      // Flip = close current position + open opposite with same size
+      // Round to lot size to avoid errors
+      const rawDoubleAmount = positionSize * 2;
+      const doubleAmount = Math.floor(rawDoubleAmount / lotSize) * lotSize;
+
+      await createMarketOrder.mutateAsync({
+        symbol: symbol,
+        side: isLong ? 'ask' : 'bid', // Opposite side to flip
+        amount: doubleAmount.toFixed(8),
+        reduceOnly: false,
+        slippage_percent: '1',
+      });
+
+      onClose();
+    } catch (error) {
+      console.error('Failed to flip position:', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface-850 border border-surface-800 rounded-xl shadow-2xl w-full max-w-md mx-4 overflow-hidden flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-surface-800">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+              <span className="text-white font-mono text-lg font-bold">
+                {symbol}
+              </span>
+              <span className={`text-xs font-bold px-2 py-1 rounded ${
+                isLong
+                  ? 'bg-win-500/30 text-win-400'
+                  : 'bg-loss-500/30 text-loss-400'
+              }`}>
+                {isLong ? 'LONG' : 'SHORT'}
+              </span>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-surface-400 hover:text-white transition-colors p-1 hover:bg-surface-800 rounded"
+          >
+            <CloseIcon sx={{ fontSize: 20 }} />
+          </button>
+        </div>
+
+        {/* Position Info */}
+        <div className="px-6 py-4 bg-surface-900/50 border-b border-surface-800">
+          <div className="grid grid-cols-3 gap-3">
+            <div className="text-center">
+              <div className="text-xs text-surface-500 mb-1">Size</div>
+              <div className="text-sm text-white font-mono">
+                {positionSize.toFixed(6)} {symbol}
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="text-xs text-surface-500 mb-1">Pos Value</div>
+              <div className="text-sm text-white font-mono">
+                ${(positionSize * currentPrice).toFixed(2)}
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="text-xs text-surface-500 mb-1">Margin</div>
+              <div className="text-sm text-white font-mono">
+                ${margin.toFixed(2)}
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="text-xs text-surface-500 mb-1">Entry</div>
+              <div className="text-sm text-white font-mono">
+                ${entryPrice.toLocaleString(undefined, { minimumFractionDigits: 3, maximumFractionDigits: 3 })}
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="text-xs text-surface-500 mb-1">Mark</div>
+              <div className="text-sm text-white font-mono">
+                ${currentPrice.toLocaleString(undefined, { minimumFractionDigits: 3, maximumFractionDigits: 3 })}
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="text-xs text-surface-500 mb-1 flex items-center justify-center gap-1">
+                <TrendingDownIcon sx={{ fontSize: 12 }} className="text-loss-400" />
+                Liq
+              </div>
+              <div className="text-sm text-loss-400 font-mono">
+                ${position.liq_price ? parseFloat(position.liq_price).toLocaleString() : 'N/A'}
+              </div>
+            </div>
+            <div className="col-span-3 text-center">
+              <div className="text-xs text-surface-500 mb-1">Unrealized PnL</div>
+              <div className={`text-sm font-mono ${
+                isProfitable ? 'text-win-400' : 'text-loss-400'
+              }`}>
+                {isProfitable ? '+' : ''}${pnl.toFixed(2)} ({isProfitable ? '+' : ''}{pnlPercent.toFixed(2)}%)
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-surface-800">
+          <button
+            onClick={() => setActiveTab('close')}
+            className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'close'
+                ? 'bg-surface-800 text-white border-b-2 border-primary-500'
+                : 'text-surface-400 hover:text-white hover:bg-surface-800/50'
+            }`}
+          >
+            <CloseIcon sx={{ fontSize: 18 }} />
+            Close
+          </button>
+          <button
+            onClick={() => setActiveTab('tpsl')}
+            className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'tpsl'
+                ? 'bg-surface-800 text-white border-b-2 border-primary-500'
+                : 'text-surface-400 hover:text-white hover:bg-surface-800/50'
+            }`}
+          >
+            <svg
+              className="w-[18px] h-[18px]"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+            TP/SL
+          </button>
+          <button
+            onClick={() => setActiveTab('flip')}
+            className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 text-sm font-medium transition-colors ${
+              activeTab === 'flip'
+                ? 'bg-surface-800 text-white border-b-2 border-primary-500'
+                : 'text-surface-400 hover:text-white hover:bg-surface-800/50'
+            }`}
+          >
+            <SwapVertIcon sx={{ fontSize: 18 }} />
+            Flip
+          </button>
+        </div>
+
+        {/* Tab Content - Fixed height to prevent layout shift */}
+        <div className="px-6 py-4 overflow-y-auto" style={{ minHeight: '280px', maxHeight: '280px' }}>
+          {activeTab === 'close' && (
+            <div className="space-y-4">
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <label className="text-xs text-surface-400">
+                    Close Amount
+                  </label>
+                  <span className="text-sm font-mono font-medium text-white">
+                    {closePercentage.toFixed(0)}%
+                  </span>
+                </div>
+
+                {/* Quick percentage buttons */}
+                <div className="grid grid-cols-4 gap-2 mb-3">
+                  {[25, 50, 75, 100].map((pct) => (
+                    <button
+                      key={pct}
+                      onClick={() => setCloseAmount(pct.toString())}
+                      className={`py-1.5 px-3 text-xs font-medium rounded transition-colors ${
+                        closePercentage === pct
+                          ? 'bg-primary-500 text-white'
+                          : 'bg-surface-800 text-surface-400 hover:bg-surface-700 hover:text-white'
+                      }`}
+                    >
+                      {pct}%
+                    </button>
+                  ))}
+                </div>
+
+                <input
+                  type="range"
+                  min="1"
+                  max="100"
+                  value={closeAmount}
+                  onChange={(e) => setCloseAmount(e.target.value)}
+                  className="w-full h-2 bg-surface-700 rounded-lg appearance-none cursor-pointer accent-primary-500"
+                  style={{
+                    background: `linear-gradient(to right, #f97316 0%, #f97316 ${closePercentage}%, #27272a ${closePercentage}%, #27272a 100%)`
+                  }}
+                />
+                <div className="text-xs text-surface-500 mt-2">
+                  {closeAmountTokens.toFixed(8)} {symbol} (${(closeAmountTokens * currentPrice).toFixed(2)})
+                </div>
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'tpsl' && (
+            <div className="space-y-4">
+              {/* Take Profit */}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <label className="text-sm text-surface-400">TP Price</label>
+                  {takeProfitPrice && (() => {
+                    const tp = parseFloat(takeProfitPrice);
+                    const tpGain = isLong
+                      ? (tp - entryPrice) * positionSize
+                      : (entryPrice - tp) * positionSize;
+                    const tpPercent = margin > 0 ? (tpGain / margin) * 100 : 0;
+                    return (
+                      <div className="flex items-center gap-2 text-xs">
+                        <span className="text-surface-500">Gain</span>
+                        <span className={`font-mono ${tpGain >= 0 ? 'text-win-400' : 'text-loss-400'}`}>
+                          ${tpGain.toFixed(2)}
+                        </span>
+                        <span className="text-surface-600">|</span>
+                        <span className={`font-mono ${tpPercent >= 0 ? 'text-win-400' : 'text-loss-400'}`}>
+                          {tpPercent >= 0 ? '+' : ''}{tpPercent.toFixed(0)}%
+                        </span>
+                      </div>
+                    );
+                  })()}
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={takeProfitPrice}
+                    onChange={(e) => setTakeProfitPrice(e.target.value)}
+                    placeholder="0.00"
+                    className="flex-1 bg-surface-900 border border-surface-800 rounded-lg px-3 py-2 text-white font-mono focus:outline-none focus:border-primary-500"
+                  />
+                  <span className="text-surface-400 text-sm">USD</span>
+                </div>
+                <div className="flex gap-2">
+                  {[25, 50, 75, 100].map((pct) => {
+                    // Pass position size as third parameter (same as TpSlModal)
+                    const tpPrice = calculateTpPrice(pct, positionInfo, positionSize);
+                    return (
+                      <button
+                        key={pct}
+                        onClick={() => setTakeProfitPrice(tpPrice.toFixed(2))}
+                        className="flex-1 py-1.5 rounded text-xs font-medium bg-surface-700 text-surface-300 hover:bg-surface-600 hover:text-white transition-colors"
+                      >
+                        {pct}%
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Stop Loss */}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <label className="text-sm text-surface-400">SL Price</label>
+                  {stopLossPrice && (() => {
+                    const sl = parseFloat(stopLossPrice);
+                    const slLoss = isLong
+                      ? (sl - entryPrice) * positionSize
+                      : (entryPrice - sl) * positionSize;
+                    const slPercent = margin > 0 ? (slLoss / margin) * 100 : 0;
+                    return (
+                      <div className="flex items-center gap-2 text-xs">
+                        <span className="text-surface-500">Loss</span>
+                        <span className={`font-mono ${slLoss <= 0 ? 'text-loss-400' : 'text-win-400'}`}>
+                          ${slLoss.toFixed(2)}
+                        </span>
+                        <span className="text-surface-600">|</span>
+                        <span className={`font-mono ${slPercent <= 0 ? 'text-loss-400' : 'text-win-400'}`}>
+                          {slPercent.toFixed(0)}%
+                        </span>
+                      </div>
+                    );
+                  })()}
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={stopLossPrice}
+                    onChange={(e) => setStopLossPrice(e.target.value)}
+                    placeholder="0.00"
+                    className="flex-1 bg-surface-900 border border-surface-800 rounded-lg px-3 py-2 text-white font-mono focus:outline-none focus:border-primary-500"
+                  />
+                  <span className="text-surface-400 text-sm">USD</span>
+                </div>
+                <div className="flex gap-2">
+                  {[-25, -50, -75, -100].map((pct) => {
+                    // Pass position size as third parameter (same as TpSlModal)
+                    const slPrice = calculateSlPrice(pct, positionInfo, positionSize);
+                    return (
+                      <button
+                        key={pct}
+                        onClick={() => setStopLossPrice(slPrice.toFixed(2))}
+                        className="flex-1 py-1.5 rounded text-xs font-medium bg-surface-700 text-surface-300 hover:bg-surface-600 hover:text-white transition-colors"
+                      >
+                        {pct}%
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+            </div>
+          )}
+
+          {activeTab === 'flip' && (
+            <div className="space-y-4">
+              <div className="bg-surface-900/50 border border-surface-800 rounded-lg p-4">
+                <div className="text-sm text-surface-400 mb-2">
+                  Flipping will close your current position and open a new position in the opposite direction with the same size.
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-surface-400">Current:</span>
+                  <span className={`font-medium ${isLong ? 'text-win-400' : 'text-loss-400'}`}>
+                    {positionSize.toFixed(6)} {symbol} {isLong ? 'LONG' : 'SHORT'}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-sm mt-2">
+                  <span className="text-surface-400">After flip:</span>
+                  <span className={`font-medium ${!isLong ? 'text-win-400' : 'text-loss-400'}`}>
+                    {positionSize.toFixed(6)} {symbol} {!isLong ? 'LONG' : 'SHORT'}
+                  </span>
+                </div>
+              </div>
+
+            </div>
+          )}
+        </div>
+
+        {/* Modal Footer - Action Buttons */}
+        <div className="px-6 py-4 border-t border-surface-800 bg-surface-900/30 space-y-3">
+          {activeTab === 'close' && (
+            <>
+              <button
+                onClick={handleClose}
+                disabled={isSubmitting || closeAmountTokens === 0}
+                className="w-full bg-loss-500 hover:bg-loss-600 disabled:bg-surface-700 disabled:text-surface-500 text-white font-medium py-3 px-4 rounded-lg transition-colors"
+              >
+                {isSubmitting ? 'Closing Position...' : `Close ${closePercentage.toFixed(0)}% at Market`}
+              </button>
+              <button
+                onClick={() => {
+                  window.location.href = `/trade?symbol=${symbolBase}`;
+                }}
+                className="w-full bg-surface-800 hover:bg-surface-700 text-surface-300 hover:text-white font-medium py-2.5 px-4 rounded-lg transition-colors text-sm"
+              >
+                Go to Terminal
+              </button>
+            </>
+          )}
+
+          {activeTab === 'tpsl' && (
+            <>
+              <button
+                onClick={handleSetTpSl}
+                disabled={isSubmitting || (!takeProfitPrice && !stopLossPrice)}
+                className="w-full bg-primary-500 hover:bg-primary-600 disabled:bg-surface-700 disabled:text-surface-500 text-white font-medium py-3 px-4 rounded-lg transition-colors"
+              >
+                {isSubmitting ? 'Setting TP/SL...' : 'Set TP/SL'}
+              </button>
+              <button
+                onClick={() => {
+                  window.location.href = `/trade?symbol=${symbolBase}`;
+                }}
+                className="w-full bg-surface-800 hover:bg-surface-700 text-surface-300 hover:text-white font-medium py-2.5 px-4 rounded-lg transition-colors text-sm"
+              >
+                Go to Terminal
+              </button>
+            </>
+          )}
+
+          {activeTab === 'flip' && (
+            <>
+              <button
+                onClick={handleFlip}
+                disabled={isSubmitting}
+                className="w-full bg-primary-500 hover:bg-primary-600 disabled:bg-surface-700 disabled:text-surface-500 text-white font-medium py-3 px-4 rounded-lg transition-colors"
+              >
+                {isSubmitting ? 'Flipping Position...' : `Flip to ${!isLong ? 'LONG' : 'SHORT'}`}
+              </button>
+              <button
+                onClick={() => {
+                  window.location.href = `/trade?symbol=${symbolBase}`;
+                }}
+                className="w-full bg-surface-800 hover:bg-surface-700 text-surface-300 hover:text-white font-medium py-2.5 px-4 rounded-lg transition-colors text-sm"
+              >
+                Go to Terminal
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/QuickPositionsBar.tsx
+++ b/apps/web/src/components/QuickPositionsBar.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { usePositions, useAccountSettings } from '@/hooks/usePositions';
+import { usePrices } from '@/hooks/usePrices';
+import { QuickPositionModal } from './QuickPositionModal';
+import type { Position } from '@/hooks/usePacificaWebSocket';
+import ViewListIcon from '@mui/icons-material/ViewList';
+import { calculatePositionMetrics } from '@/lib/trading/utils';
+
+/**
+ * Format price for quick display with fixed width to prevent navbar jumping
+ * Rounds to appropriate precision based on price magnitude
+ */
+function formatQuickPrice(price: number): string {
+  if (price >= 10000) {
+    // For prices >= 10k: show as "12.3K" or "123K"
+    const k = price / 1000;
+    return k >= 100 ? `${k.toFixed(0)}K` : `${k.toFixed(1)}K`;
+  } else if (price >= 1000) {
+    // For prices 1k-10k: show as "1,234" (no decimals)
+    return price.toFixed(0);
+  } else if (price >= 100) {
+    // For prices 100-1k: show as "123.4" (1 decimal)
+    return price.toFixed(1);
+  } else if (price >= 10) {
+    // For prices 10-100: show as "12.34" (2 decimals)
+    return price.toFixed(2);
+  } else if (price >= 1) {
+    // For prices 1-10: show as "1.234" (3 decimals)
+    return price.toFixed(3);
+  } else {
+    // For prices < 1: show as "0.1234" (4 decimals)
+    return price.toFixed(4);
+  }
+}
+
+// Max leverage per symbol (from useAccount.ts)
+const MAX_LEVERAGE: Record<string, number> = {
+  BTC: 50, ETH: 50, SOL: 20, HYPE: 20, XRP: 20, DOGE: 20, LINK: 20, AVAX: 20,
+  SUI: 10, BNB: 10, AAVE: 10, ARB: 10, OP: 10, APT: 10, INJ: 10, TIA: 10,
+  SEI: 10, WIF: 10, JUP: 10, PENDLE: 10, RENDER: 10, FET: 10, ZEC: 10,
+  PAXG: 10, ENA: 10, KPEPE: 10, XMR: 10, LTC: 10, LIT: 10, FARTCOIN: 10,
+  XAG: 10, NVDA: 10, BCH: 10, WLFI: 10, XPL: 10, TAO: 10, ADA: 10, CL: 10,
+  UNI: 10, VIRTUAL: 10, ICP: 10, KBONK: 10, ASTER: 10, TRUMP: 10, LDO: 10,
+  PENGU: 10, NEAR: 10, ZK: 10, WLD: 10, PIPPIN: 10, ZZ: 10, STRK: 10,
+  CRV: 10, MON: 10, PUMP: 10, '1000PEPE': 10, '1000BONK': 10,
+};
+
+/**
+ * QuickPositionsBar - Shows active positions carousel in navbar
+ */
+export function QuickPositionsBar() {
+  const { data: positions, isLoading } = usePositions();
+  const { prices, getPrice } = usePrices();
+  const { data: accountSettings } = useAccountSettings();
+
+  // Build leverage map (same as useAccount.ts)
+  const leverageMap = useMemo(() => {
+    const map: Record<string, number> = {};
+    if (accountSettings && Array.isArray(accountSettings)) {
+      accountSettings.forEach((setting: any) => {
+        if (setting.symbol && setting.leverage) {
+          map[setting.symbol] = setting.leverage;
+        }
+      });
+    }
+    return map;
+  }, [accountSettings]);
+
+  const [selectedPosition, setSelectedPosition] = useState<Position | null>(null);
+  const [showModal, setShowModal] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [scrollLeft, setScrollLeft] = useState(0);
+
+  // Don't show anything if no positions or loading
+  if (isLoading || !positions || positions.length === 0) {
+    return null;
+  }
+
+  const handlePositionClick = (position: Position) => {
+    if (!isDragging) {
+      setSelectedPosition(position);
+      setShowModal(true);
+    }
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (!scrollRef.current) return;
+    setIsDragging(true);
+    setStartX(e.pageX - scrollRef.current.offsetLeft);
+    setScrollLeft(scrollRef.current.scrollLeft);
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!isDragging || !scrollRef.current) return;
+    e.preventDefault();
+    const x = e.pageX - scrollRef.current.offsetLeft;
+    const walk = (x - startX) * 2; // Scroll speed multiplier
+    scrollRef.current.scrollLeft = scrollLeft - walk;
+  };
+
+  const handleMouseUp = () => {
+    setIsDragging(false);
+  };
+
+  const handleMouseLeave = () => {
+    setIsDragging(false);
+  };
+
+  const handleCloseModal = () => {
+    setShowModal(false);
+    setSelectedPosition(null);
+  };
+
+  return (
+    <>
+      {/* Desktop with slider: Only show carousel on large screens (above 1024x841) */}
+      <div
+        ref={scrollRef}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseLeave}
+        className="hidden lg:flex items-center gap-2 ml-6 mr-6 flex-1 overflow-x-auto scrollbar-hide cursor-grab active:cursor-grabbing"
+      >
+        {positions.map((position: Position) => {
+          const symbol = position.symbol;
+          const symbolBase = symbol.replace('-USD', '');
+          const priceData = getPrice(`${symbolBase}-USD`);
+          const markPrice = priceData?.price || parseFloat(position.entry_price);
+
+          // Get leverage from settings or default
+          const leverage = leverageMap[symbolBase] || MAX_LEVERAGE[symbolBase] || 10;
+
+          // Use centralized calculation (handles cross margin correctly)
+          const metrics = calculatePositionMetrics({
+            position,
+            markPrice,
+            leverage,
+          });
+
+          const isProfitable = metrics.unrealizedPnl >= 0;
+
+          return (
+            <button
+              key={`${symbol}-${position.side}`}
+              onClick={() => handlePositionClick(position)}
+              className={`flex-shrink-0 flex items-center justify-between px-3 py-2.5 rounded-lg transition-colors ${
+                isProfitable
+                  ? 'bg-win-500/10 hover:bg-win-500/15'
+                  : 'bg-loss-500/10 hover:bg-loss-500/15'
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                {/* Symbol + Side Badge */}
+                <span className="text-white font-mono text-sm font-medium">
+                  {symbolBase}
+                </span>
+                <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
+                  metrics.side === 'LONG'
+                    ? 'bg-win-500/30 text-win-400'
+                    : 'bg-loss-500/30 text-loss-400'
+                }`}>
+                  {metrics.side}
+                </span>
+              </div>
+
+              <div className="flex items-center gap-3">
+                {/* PnL */}
+                <span className={`text-xs font-mono font-medium min-w-[55px] text-right ${
+                  isProfitable ? 'text-win-400' : 'text-loss-400'
+                }`}>
+                  {isProfitable ? '+' : ''}{metrics.unrealizedPnlPercent.toFixed(2)}%
+                </span>
+
+                {/* Current Price */}
+                <span className="text-xs text-surface-200 font-mono min-w-[60px] text-right">
+                  ${formatQuickPrice(markPrice)}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Quick Action Modal */}
+      {selectedPosition && (
+        <QuickPositionModal
+          position={selectedPosition}
+          isOpen={showModal}
+          onClose={handleCloseModal}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * QuickPositionsDropdown - Dropdown icon for navbar right section
+ */
+export function QuickPositionsDropdown() {
+  const { data: positions, isLoading } = usePositions();
+  const { prices, getPrice } = usePrices();
+  const { data: accountSettings } = useAccountSettings();
+
+  // Build leverage map (same as useAccount.ts)
+  const leverageMap = useMemo(() => {
+    const map: Record<string, number> = {};
+    if (accountSettings && Array.isArray(accountSettings)) {
+      accountSettings.forEach((setting: any) => {
+        if (setting.symbol && setting.leverage) {
+          map[setting.symbol] = setting.leverage;
+        }
+      });
+    }
+    return map;
+  }, [accountSettings]);
+
+  const [selectedPosition, setSelectedPosition] = useState<Position | null>(null);
+  const [showModal, setShowModal] = useState(false);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setShowDropdown(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Don't show anything if no positions or loading
+  if (isLoading || !positions || positions.length === 0) {
+    return null;
+  }
+
+  const handlePositionClick = (position: Position) => {
+    setSelectedPosition(position);
+    setShowModal(true);
+    setShowDropdown(false);
+  };
+
+  const handleCloseModal = () => {
+    setShowModal(false);
+    setSelectedPosition(null);
+  };
+
+  return (
+    <>
+      {/* Dropdown button */}
+      <div className="relative" ref={dropdownRef}>
+        <button
+          onClick={() => setShowDropdown(!showDropdown)}
+          className="relative flex items-center justify-center px-2 py-1.5 bg-surface-800 hover:bg-surface-700 rounded transition-colors"
+        >
+          <ViewListIcon className="text-surface-400" sx={{ fontSize: 20 }} />
+        </button>
+
+        {/* Dropdown menu */}
+        {showDropdown && (
+          <div className="absolute top-full right-0 mt-2 w-80 bg-surface-850 rounded-lg shadow-xl border border-surface-800 overflow-hidden z-50">
+            {positions.map((position: Position) => {
+              const symbol = position.symbol;
+              const symbolBase = symbol.replace('-USD', '');
+              const priceData = getPrice(`${symbolBase}-USD`);
+              const markPrice = priceData?.price || parseFloat(position.entry_price);
+
+              // Get leverage from settings or default
+              const leverage = leverageMap[symbolBase] || MAX_LEVERAGE[symbolBase] || 10;
+
+              // Use centralized calculation (handles cross margin correctly)
+              const metrics = calculatePositionMetrics({
+                position,
+                markPrice,
+                leverage,
+              });
+
+              const isProfitable = metrics.unrealizedPnl >= 0;
+
+              return (
+                <button
+                  key={`${symbol}-${position.side}`}
+                  onClick={() => handlePositionClick(position)}
+                  className={`w-full flex items-center justify-between px-4 py-3 transition-colors ${
+                    isProfitable
+                      ? 'bg-win-500/10 hover:bg-win-500/15'
+                      : 'bg-loss-500/10 hover:bg-loss-500/15'
+                  } border-b border-surface-800 last:border-b-0`}
+                >
+                  <div className="flex items-center gap-2">
+                    {/* Symbol + Side Badge */}
+                    <span className="text-white font-mono text-sm font-medium">
+                      {symbolBase}
+                    </span>
+                    <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
+                      metrics.side === 'LONG'
+                        ? 'bg-win-500/30 text-win-400'
+                        : 'bg-loss-500/30 text-loss-400'
+                    }`}>
+                      {metrics.side}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center gap-3">
+                    {/* PnL */}
+                    <span className={`text-xs font-mono font-medium min-w-[55px] text-right ${
+                      isProfitable ? 'text-win-400' : 'text-loss-400'
+                    }`}>
+                      {isProfitable ? '+' : ''}{metrics.unrealizedPnlPercent.toFixed(2)}%
+                    </span>
+
+                    {/* Current Price */}
+                    <span className="text-xs text-surface-200 font-mono min-w-[60px] text-right">
+                      ${formatQuickPrice(markPrice)}
+                    </span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Quick Action Modal */}
+      {selectedPosition && (
+        <QuickPositionModal
+          position={selectedPosition}
+          isOpen={showModal}
+          onClose={handleCloseModal}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/SettingsModal.tsx
+++ b/apps/web/src/components/SettingsModal.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import CloseIcon from '@mui/icons-material/Close';
+
+interface SettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
+  const [showQuickBar, setShowQuickBar] = useState(true);
+  const [showWallet, setShowWallet] = useState(true);
+  const [showNotifications, setShowNotifications] = useState(true);
+
+  // Load settings from localStorage on mount
+  useEffect(() => {
+    const saved = localStorage.getItem('tfc-settings');
+    if (saved) {
+      try {
+        const settings = JSON.parse(saved);
+        setShowQuickBar(settings.showQuickBar ?? true);
+        setShowWallet(settings.showWallet ?? true);
+        setShowNotifications(settings.showNotifications ?? true);
+      } catch (e) {
+        // Ignore parse errors
+      }
+    }
+  }, []);
+
+  // Save settings to localStorage whenever they change
+  useEffect(() => {
+    const settings = { showQuickBar, showWallet, showNotifications };
+    localStorage.setItem('tfc-settings', JSON.stringify(settings));
+
+    // Dispatch custom event so other components can listen
+    window.dispatchEvent(new CustomEvent('tfc-settings-changed', { detail: settings }));
+  }, [showQuickBar, showWallet, showNotifications]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[100]" onClick={onClose}>
+      <div
+        className="bg-surface-850 border border-surface-800 rounded-lg shadow-xl max-w-md w-full mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-surface-800">
+          <h2 className="text-lg font-semibold text-white">Settings</h2>
+          <button
+            onClick={onClose}
+            className="text-surface-400 hover:text-white transition-colors"
+          >
+            <CloseIcon sx={{ fontSize: 20 }} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-4 space-y-4">
+          <div className="space-y-3">
+            <h3 className="text-sm font-medium text-surface-300">Navbar Components</h3>
+
+            {/* Quick Bar Toggle */}
+            <div className="flex items-center justify-between py-2">
+              <div>
+                <div className="text-sm text-white">Quick Positions Bar</div>
+                <div className="text-xs text-surface-500">Show active positions in navbar</div>
+              </div>
+              <button
+                onClick={() => setShowQuickBar(!showQuickBar)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  showQuickBar ? 'bg-primary-500' : 'bg-surface-700'
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                    showQuickBar ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
+
+            {/* Wallet Toggle */}
+            <div className="flex items-center justify-between py-2">
+              <div>
+                <div className="text-sm text-white">Balance Display</div>
+                <div className="text-xs text-surface-500">Show balance and deposit/withdraw</div>
+              </div>
+              <button
+                onClick={() => setShowWallet(!showWallet)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  showWallet ? 'bg-primary-500' : 'bg-surface-700'
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                    showWallet ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
+
+            {/* Notifications Toggle */}
+            <div className="flex items-center justify-between py-2">
+              <div>
+                <div className="text-sm text-white">Notifications</div>
+                <div className="text-xs text-surface-500">Show notification bell icon</div>
+              </div>
+              <button
+                onClick={() => setShowNotifications(!showNotifications)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  showNotifications ? 'bg-primary-500' : 'bg-surface-700'
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                    showNotifications ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-surface-800 bg-surface-900/30">
+          <button
+            onClick={onClose}
+            className="w-full bg-primary-500 hover:bg-primary-600 text-white font-medium py-2 px-4 rounded-lg transition-colors"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -29,3 +29,5 @@ export type { UserPrize } from './useMyPrizes';
 export { useBetaAccess } from './useBetaAccess';
 export { useUrlState, useMultipleUrlState } from './useUrlState';
 export type { UseUrlStateOptions } from './useUrlState';
+export { useSettings } from './useSettings';
+export type { Settings } from './useSettings';

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export interface Settings {
+  showQuickBar: boolean;
+  showWallet: boolean;
+  showNotifications: boolean;
+}
+
+const defaultSettings: Settings = {
+  showQuickBar: true,
+  showWallet: true,
+  showNotifications: true,
+};
+
+export function useSettings() {
+  const [settings, setSettings] = useState<Settings>(defaultSettings);
+
+  useEffect(() => {
+    // Load from localStorage on mount
+    const saved = localStorage.getItem('tfc-settings');
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        setSettings({ ...defaultSettings, ...parsed });
+      } catch (e) {
+        // Ignore parse errors
+      }
+    }
+
+    // Listen for settings changes from other components
+    const handleSettingsChanged = (event: CustomEvent<Settings>) => {
+      setSettings(event.detail);
+    };
+
+    window.addEventListener('tfc-settings-changed', handleSettingsChanged as EventListener);
+
+    return () => {
+      window.removeEventListener('tfc-settings-changed', handleSettingsChanged as EventListener);
+    };
+  }, []);
+
+  return settings;
+}

--- a/apps/web/src/lib/trading/utils.ts
+++ b/apps/web/src/lib/trading/utils.ts
@@ -1,0 +1,748 @@
+/**
+ * Centralized trading utilities
+ * Source: TpSlModal.tsx (lines 166-187)
+ */
+
+export interface PositionInfo {
+  side: 'LONG' | 'SHORT';
+  entryPrice: number;
+  margin: number;
+  sizeInToken: number;
+}
+
+/**
+ * Calculate TP price based on percentage gain
+ * Formula: TP = entryPrice ± (margin × gainPercent / 100) / size
+ */
+export function calculateTpPrice(
+  gainPercent: number,
+  position: PositionInfo,
+  size?: number
+): number {
+  const effectiveSize = size || position.sizeInToken;
+  const margin = position.margin * (effectiveSize / position.sizeInToken);
+  const gainAmount = (margin * gainPercent) / 100;
+
+  if (position.side === 'LONG') {
+    return position.entryPrice + gainAmount / effectiveSize;
+  } else {
+    return position.entryPrice - gainAmount / effectiveSize;
+  }
+}
+
+/**
+ * Calculate SL price based on percentage loss
+ * Formula: SL = entryPrice ∓ (margin × lossPercent / 100) / size
+ */
+export function calculateSlPrice(
+  lossPercent: number,
+  position: PositionInfo,
+  size?: number
+): number {
+  const effectiveSize = size || position.sizeInToken;
+  const margin = position.margin * (effectiveSize / position.sizeInToken);
+  const lossAmount = (margin * Math.abs(lossPercent)) / 100;
+
+  if (position.side === 'LONG') {
+    return position.entryPrice - lossAmount / effectiveSize;
+  } else {
+    return position.entryPrice + lossAmount / effectiveSize;
+  }
+}
+
+/**
+ * Calculate PnL from price difference
+ */
+export function calculatePnl(
+  entryPrice: number,
+  currentPrice: number,
+  size: number,
+  side: 'LONG' | 'SHORT'
+): number {
+  const priceDiff = side === 'LONG'
+    ? currentPrice - entryPrice
+    : entryPrice - currentPrice;
+  return priceDiff * size;
+}
+
+/**
+ * Calculate PnL percentage (ROI based on margin)
+ */
+export function calculatePnlPercent(pnl: number, margin: number): number {
+  if (margin === 0) return 0;
+  return (pnl / margin) * 100;
+}
+
+/**
+ * Format price for display
+ */
+export function formatPrice(price: number): string {
+  if (price >= 10000) return price.toFixed(0);
+  if (price >= 100) return price.toFixed(2);
+  if (price >= 1) return price.toFixed(4);
+  return price.toFixed(6);
+}
+
+/**
+ * Raw position from Pacifica API
+ */
+export interface RawPosition {
+  symbol: string;
+  side: 'bid' | 'ask';
+  amount: string;
+  entry_price: string;
+  margin: string;
+  funding: string;
+  isolated: boolean;
+  liq_price: string | null;
+}
+
+/**
+ * Parameters for calculating position metrics
+ */
+export interface EnhancedPositionParams {
+  position: RawPosition;
+  markPrice: number; // Current price from usePrices
+  leverage: number; // From account settings or MAX_LEVERAGE
+}
+
+/**
+ * Enhanced position metrics with correctly calculated margin and PnL
+ */
+export interface EnhancedPositionResult {
+  entryPrice: number;
+  markPrice: number;
+  amount: number;
+  side: 'LONG' | 'SHORT';
+  margin: number; // Correctly calculated for cross/isolated
+  unrealizedPnl: number;
+  unrealizedPnlPercent: number;
+}
+
+/**
+ * Calculate enhanced position data with correct margin and PnL
+ * Extracted from terminal logic (trade/page.tsx:707-735)
+ *
+ * Handles the critical difference between isolated and cross margin:
+ * - Isolated: Uses margin from API
+ * - Cross: Calculates margin = positionValue / leverage (API returns '0' for cross)
+ */
+export function calculatePositionMetrics(params: EnhancedPositionParams): EnhancedPositionResult {
+  const { position, markPrice, leverage } = params;
+
+  const entryPrice = parseFloat(position.entry_price);
+  const amount = parseFloat(position.amount);
+  const isLong = position.side === 'bid';
+  const isolated = position.isolated ?? false;
+
+  // Calculate margin correctly (terminal logic)
+  // For cross margin, API returns margin='0', so we must calculate it
+  const apiMargin = parseFloat(position.margin || '0');
+  const positionValue = amount * entryPrice;
+  const margin = isolated && apiMargin > 0
+    ? apiMargin
+    : positionValue / leverage;
+
+  // Calculate PnL using existing centralized functions
+  const side = isLong ? 'LONG' : 'SHORT';
+  const pnl = calculatePnl(entryPrice, markPrice, amount, side);
+  const pnlPercent = calculatePnlPercent(pnl, margin);
+
+  return {
+    entryPrice,
+    markPrice,
+    amount,
+    side,
+    margin,
+    unrealizedPnl: pnl,
+    unrealizedPnlPercent: pnlPercent,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// PRIORITY 1: CRITICAL FUNCTIONS
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Parameters for liquidation price calculation
+ */
+export interface LiquidationPriceParams {
+  entryPrice: number;
+  sizeInToken: number;
+  margin: number;
+  leverage: number;
+  side: 'LONG' | 'SHORT';
+  apiLiqPrice?: number;
+  accountEquity?: number;
+  isolated?: boolean;
+}
+
+/**
+ * Calculate liquidation price using Pacifica's official formula
+ * Extracted from terminal logic (trade/page.tsx:740-756)
+ *
+ * Formula: liquidation_price = [price - (side * position_margin) / position_size] / (1 - side / max_leverage / 2)
+ * Where: side = 1 for LONG, -1 for SHORT
+ *
+ * Falls back to API liq price if available (from WebSocket)
+ * For cross margin, uses account equity if available
+ */
+export function calculateLiquidationPrice(params: LiquidationPriceParams): number {
+  const { entryPrice, sizeInToken, margin, leverage, side, apiLiqPrice, accountEquity, isolated } = params;
+
+  // If we have real liq price from Pacifica WebSocket, use it
+  if (apiLiqPrice && apiLiqPrice > 0) {
+    return apiLiqPrice;
+  }
+
+  // Calculate using Pacifica's official formula
+  const sideMultiplier = side === 'LONG' ? 1 : -1;
+  const positionMargin = isolated && margin > 0
+    ? margin
+    : accountEquity && accountEquity > 0
+      ? accountEquity
+      : (sizeInToken * entryPrice) / leverage;
+
+  const numerator = entryPrice - (sideMultiplier * positionMargin) / sizeInToken;
+  const denominator = 1 - sideMultiplier / leverage / 2;
+
+  return Math.max(0, numerator / denominator);
+}
+
+/**
+ * Order interface for TP/SL filtering
+ */
+export interface Order {
+  id: string;
+  symbol: string;
+  side: 'LONG' | 'SHORT';
+  type: string;
+  size: string;
+  price: string;
+  stopPrice?: string | null;
+  reduceOnly?: boolean;
+}
+
+/**
+ * Normalized TP/SL order result
+ */
+export interface TpSlOrder {
+  orderId: string;
+  type: 'TP' | 'SL';
+  triggerPrice: number;
+  amount: number;
+  orderType: 'market' | 'limit';
+  limitPrice?: number;
+}
+
+/**
+ * Position info for TP/SL filtering
+ */
+export interface PositionForOrders {
+  symbol: string;
+  side: 'LONG' | 'SHORT';
+}
+
+/**
+ * Filter and detect Take Profit orders for a position
+ * Extracted from terminal logic (trade/page.tsx:769-795)
+ *
+ * Detects two types of TP orders:
+ * 1. Native Pacifica TP: order.type includes 'TP' or 'take_profit'
+ * 2. Hybrid TP: reduce_only LIMIT orders at profit-taking price
+ *    - For LONG: TP price is ABOVE entry price
+ *    - For SHORT: TP price is BELOW entry price
+ *
+ * TP orders are on opposite side of position (LONG → SHORT orders, SHORT → LONG orders)
+ */
+export function filterTpOrders(
+  orders: Order[],
+  position: PositionForOrders,
+  entryPrice: number
+): TpSlOrder[] {
+  const posSymbol = position.symbol.replace('-USD', '');
+  const oppositeOrderSide = position.side === 'LONG' ? 'SHORT' : 'LONG';
+
+  return orders.filter(order => {
+    const orderSymbol = order.symbol?.replace('-USD', '') || order.symbol;
+    if (orderSymbol !== posSymbol || order.side !== oppositeOrderSide) return false;
+
+    // Check for native Pacifica TP orders
+    const isNativeTP = order.type?.includes('TP') || order.type?.toLowerCase().includes('take_profit');
+    if (isNativeTP) return true;
+
+    // Check for hybrid TP (limit orders with reduce_only at profit-taking price)
+    const isLimitOrder = order.type?.toUpperCase() === 'LIMIT' || order.type?.toLowerCase() === 'limit order';
+    if (isLimitOrder && order.reduceOnly) {
+      const orderPrice = parseFloat(order.price) || 0;
+      // For LONG: TP is above entry, for SHORT: TP is below entry
+      if (position.side === 'LONG' && orderPrice > entryPrice) return true;
+      if (position.side === 'SHORT' && orderPrice < entryPrice) return true;
+    }
+
+    return false;
+  }).map(order => ({
+    orderId: order.id,
+    type: 'TP' as const,
+    triggerPrice: parseFloat(order.stopPrice || order.price) || 0,
+    amount: parseFloat(order.size) || 0,
+    orderType: (order.type?.includes('MARKET') ? 'market' : 'limit') as 'market' | 'limit',
+    limitPrice: order.type?.includes('LIMIT') ? parseFloat(order.price) : undefined,
+  }));
+}
+
+/**
+ * Filter and detect Stop Loss orders for a position
+ * Extracted from terminal logic (trade/page.tsx:803-829)
+ *
+ * Detects two types of SL orders:
+ * 1. Native Pacifica SL: order.type includes 'SL' or 'stop_loss'
+ * 2. Hybrid SL: reduce_only STOP orders at loss-limiting price
+ *    - For LONG: SL price is BELOW entry price
+ *    - For SHORT: SL price is ABOVE entry price
+ *
+ * SL orders are on opposite side of position (LONG → SHORT orders, SHORT → LONG orders)
+ */
+export function filterSlOrders(
+  orders: Order[],
+  position: PositionForOrders,
+  entryPrice: number
+): TpSlOrder[] {
+  const posSymbol = position.symbol.replace('-USD', '');
+  const oppositeOrderSide = position.side === 'LONG' ? 'SHORT' : 'LONG';
+
+  return orders.filter(order => {
+    const orderSymbol = order.symbol?.replace('-USD', '') || order.symbol;
+    if (orderSymbol !== posSymbol || order.side !== oppositeOrderSide) return false;
+
+    // Check for native Pacifica SL orders
+    const isNativeSL = order.type?.includes('SL') || order.type?.toLowerCase().includes('stop_loss');
+    if (isNativeSL) return true;
+
+    // Check for hybrid SL (stop orders with reduce_only at loss-limiting price)
+    const isStopOrder = order.type?.toUpperCase().includes('STOP') && !order.type?.includes('TP') && !order.type?.includes('SL');
+    if (isStopOrder && order.reduceOnly) {
+      const triggerPrice = parseFloat(order.stopPrice || order.price) || 0;
+      // For LONG: SL is below entry, for SHORT: SL is above entry
+      if (position.side === 'LONG' && triggerPrice < entryPrice) return true;
+      if (position.side === 'SHORT' && triggerPrice > entryPrice) return true;
+    }
+
+    return false;
+  }).map(order => ({
+    orderId: order.id,
+    type: 'SL' as const,
+    triggerPrice: parseFloat(order.stopPrice || order.price) || 0,
+    amount: parseFloat(order.size) || 0,
+    orderType: (order.type?.includes('MARKET') ? 'market' : 'limit') as 'market' | 'limit',
+    limitPrice: order.type?.includes('LIMIT') ? parseFloat(order.price) : undefined,
+  }));
+}
+
+// ─────────────────────────────────────────────────────────────
+// PRIORITY 2: HIGH-VALUE FUNCTIONS
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Round amount to lot size (floor to lot size multiple)
+ * Extracted from terminal logic (trade/page.tsx:257-261)
+ *
+ * Pacifica requires order amounts to be multiples of lot size
+ * Example: amount=0.00123456, lotSize=0.00001 → returns "0.00123"
+ */
+export function roundToLotSize(amount: number, lotSize: number): string {
+  const precision = Math.max(0, -Math.floor(Math.log10(lotSize)));
+  const rounded = Math.floor(amount / lotSize) * lotSize;
+  return rounded.toFixed(precision);
+}
+
+/**
+ * Round price to tick size (round to nearest tick size multiple)
+ * Extracted from terminal logic (trade/page.tsx:264-268)
+ *
+ * Pacifica requires prices to be multiples of tick size
+ * Example: price=65310.7, tickSize=1 → returns "65311"
+ */
+export function roundToTickSize(price: number, tickSize: number): string {
+  const rounded = Math.round(price / tickSize) * tickSize;
+  const decimals = tickSize >= 1 ? 0 : Math.ceil(-Math.log10(tickSize));
+  return rounded.toFixed(decimals);
+}
+
+/**
+ * Account interface for statistics calculation
+ */
+export interface AccountForStats {
+  accountEquity: string;
+  totalMarginUsed: string;
+  availableToSpend: string;
+  takerFee?: string;
+  makerFee?: string;
+  crossMmr?: string;
+}
+
+/**
+ * Position interface for statistics calculation
+ */
+export interface PositionForStats {
+  size: number;
+}
+
+/**
+ * Account statistics result
+ */
+export interface AccountStats {
+  takerFeePercent: string;
+  makerFeePercent: string;
+  restingOrderValue: number;
+  crossAccountLeverage: number;
+  maintenanceMargin: number;
+}
+
+/**
+ * Calculate account statistics (fees, leverage, margins)
+ * Extracted from terminal logic (trade/page.tsx:1738-1753)
+ *
+ * Calculates:
+ * - Taker/maker fees including builder fee
+ * - Resting order value (locked in pending orders)
+ * - Cross account leverage (total position value / equity)
+ * - Maintenance margin from API or 50% of margin used
+ */
+export function calculateAccountStats(
+  account: AccountForStats,
+  positions: PositionForStats[],
+  realtimeUnrealizedPnl: number,
+  builderFee: number
+): AccountStats {
+  // Fee calculations with builder fee
+  const pacificaTakerFee = parseFloat(account.takerFee || '0.0007'); // Default fallback
+  const pacificaMakerFee = parseFloat(account.makerFee || '0.000575'); // Default fallback
+  const takerFeePercent = ((pacificaTakerFee + builderFee) * 100).toFixed(4);
+  const makerFeePercent = ((pacificaMakerFee + builderFee) * 100).toFixed(4);
+
+  // Account values
+  const equity = parseFloat(account.accountEquity) || 0;
+  const marginUsed = parseFloat(account.totalMarginUsed) || 0;
+  const available = parseFloat(account.availableToSpend) || 0;
+
+  // Resting order value (locked in pending orders)
+  const restingOrderValue = Math.max(0, equity - marginUsed - available - realtimeUnrealizedPnl);
+
+  // Cross account leverage = total position value / equity
+  const totalPositionValue = positions.reduce((sum, p) => sum + p.size, 0);
+  const crossAccountLeverage = equity > 0 ? totalPositionValue / equity : 0;
+
+  // Maintenance margin from API or 50% of margin used
+  const maintenanceMargin = parseFloat(account.crossMmr || '0') || marginUsed * 0.5;
+
+  return {
+    takerFeePercent,
+    makerFeePercent,
+    restingOrderValue,
+    crossAccountLeverage,
+    maintenanceMargin,
+  };
+}
+
+/**
+ * Parameters for order amount calculation
+ */
+export interface OrderAmountParams {
+  positionSize: number;
+  leverage: number;
+  maxLeverage: number;
+  price: number;
+  lotSize: number;
+}
+
+/**
+ * Calculate order amount in tokens with leverage and lot size rounding
+ * Extracted from terminal logic (trade/page.tsx:325-336)
+ *
+ * Formula: amount = (positionSize * leverage) / price
+ * Then rounds down to lot size to avoid Pacifica API rejection
+ */
+export function calculateOrderAmount(params: OrderAmountParams): string {
+  const { positionSize, leverage, maxLeverage, price, lotSize } = params;
+
+  const effectiveLeverage = Math.min(leverage, maxLeverage);
+  const effectivePositionSize = positionSize * effectiveLeverage;
+  const rawAmount = effectivePositionSize / price;
+
+  return roundToLotSize(rawAmount, lotSize);
+}
+
+// ─────────────────────────────────────────────────────────────
+// PRIORITY 3: MEDIUM-VALUE FUNCTIONS
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Position value calculation result
+ */
+export interface PositionValues {
+  valueAtEntry: number;
+  valueAtMark: number;
+}
+
+/**
+ * Calculate position values at entry and mark prices
+ * Extracted from terminal logic (trade/page.tsx:736-737)
+ *
+ * valueAtEntry = sizeInToken * entryPrice
+ * valueAtMark = sizeInToken * markPrice
+ */
+export function calculatePositionValues(
+  sizeInToken: number,
+  entryPrice: number,
+  markPrice: number
+): PositionValues {
+  return {
+    valueAtEntry: sizeInToken * entryPrice,
+    valueAtMark: sizeInToken * markPrice,
+  };
+}
+
+/**
+ * Convert margin to position size (leveraged USD value)
+ * Extracted from terminal logic (trade/page.tsx:2015)
+ *
+ * Formula: positionSize = margin * leverage
+ */
+export function marginToPositionSize(margin: number, leverage: number, maxLeverage: number): number {
+  const effectiveLeverage = Math.min(leverage, maxLeverage);
+  return margin * effectiveLeverage;
+}
+
+/**
+ * Convert position size to margin (unleveraged USD value)
+ * Extracted from terminal logic (trade/page.tsx:2049)
+ *
+ * Formula: margin = positionSize / leverage
+ */
+export function positionSizeToMargin(positionSize: number, leverage: number, maxLeverage: number): number {
+  const effectiveLeverage = Math.min(leverage, maxLeverage);
+  return positionSize / effectiveLeverage;
+}
+
+/**
+ * Convert token amount to margin
+ * Extracted from terminal logic (trade/page.tsx:2030)
+ *
+ * Formula: margin = (tokenAmount * price) / leverage
+ */
+export function tokenToMargin(tokenAmount: number, price: number, leverage: number, maxLeverage: number): number {
+  const effectiveLeverage = Math.min(leverage, maxLeverage);
+  return (tokenAmount * price) / effectiveLeverage;
+}
+
+/**
+ * Convert position size to token amount
+ * Extracted from terminal logic (trade/page.tsx:2016)
+ *
+ * Formula: tokenAmount = positionSize / price
+ */
+export function positionSizeToTokenAmount(positionSize: number, price: number): number {
+  return price > 0 ? positionSize / price : 0;
+}
+
+/**
+ * Calculate TP price from leverage-based percentage gain (for NEW orders)
+ * Extracted from terminal logic (trade/page.tsx:2175-2181)
+ *
+ * This is different from calculateTpPrice which is for EXISTING positions
+ * This one is for setting TP on new orders using leverage-adjusted percentages
+ *
+ * Formula: priceMove = (gainPercent / 100 / leverage) * refPrice
+ * LONG: TP = refPrice + priceMove
+ * SHORT: TP = refPrice - priceMove
+ */
+export function calculateTpPriceFromLeverageGain(
+  gainPercent: number,
+  refPrice: number,
+  leverage: number,
+  maxLeverage: number,
+  side: 'LONG' | 'SHORT',
+  tickSize: number
+): string {
+  const effectiveLev = Math.min(leverage, maxLeverage);
+  const priceMove = (gainPercent / 100 / effectiveLev) * refPrice;
+  const rawPrice = side === 'LONG'
+    ? refPrice + priceMove
+    : refPrice - priceMove;
+  return roundToTickSize(rawPrice, tickSize);
+}
+
+/**
+ * Calculate SL price from leverage-based percentage loss (for NEW orders)
+ * Extracted from terminal logic (trade/page.tsx:2184-2190)
+ *
+ * This is different from calculateSlPrice which is for EXISTING positions
+ * This one is for setting SL on new orders using leverage-adjusted percentages
+ *
+ * Formula: priceMove = (lossPercent / 100 / leverage) * refPrice
+ * LONG: SL = refPrice - priceMove
+ * SHORT: SL = refPrice + priceMove
+ */
+export function calculateSlPriceFromLeverageLoss(
+  lossPercent: number,
+  refPrice: number,
+  leverage: number,
+  maxLeverage: number,
+  side: 'LONG' | 'SHORT',
+  tickSize: number
+): string {
+  const effectiveLev = Math.min(leverage, maxLeverage);
+  const priceMove = (Math.abs(lossPercent) / 100 / effectiveLev) * refPrice;
+  const rawPrice = side === 'LONG'
+    ? refPrice - priceMove
+    : refPrice + priceMove;
+  return roundToTickSize(rawPrice, tickSize);
+}
+
+/**
+ * Position interface for aggregation
+ */
+export interface PositionForAggregation {
+  unrealizedPnl: number;
+  margin: number;
+}
+
+/**
+ * Aggregated position metrics result
+ */
+export interface PositionAggregates {
+  totalUnrealizedPnl: number;
+  totalMargin: number;
+  roi: number;
+}
+
+/**
+ * Aggregate position metrics (total PnL, margin, ROI)
+ * Extracted from terminal logic (trade/page.tsx:920-926)
+ *
+ * Calculates:
+ * - Total unrealized PnL across all positions
+ * - Total margin used
+ * - ROI = (totalPnl / totalMargin) * 100
+ */
+export function aggregatePositionMetrics(positions: PositionForAggregation[]): PositionAggregates {
+  const totalUnrealizedPnl = positions.reduce((sum, pos) => sum + pos.unrealizedPnl, 0);
+  const totalMargin = positions.reduce((sum, pos) => sum + pos.margin, 0);
+  const roi = totalMargin > 0 ? (totalUnrealizedPnl / totalMargin) * 100 : 0;
+
+  return {
+    totalUnrealizedPnl,
+    totalMargin,
+    roi,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// PRIORITY 4: LOWER-VALUE FUNCTIONS
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Position interface for filtering
+ */
+export interface PositionForFiltering {
+  symbol: string;
+}
+
+/**
+ * Filter positions by blocked symbols (for fight mode)
+ * Extracted from terminal logic (trade/page.tsx:911-913)
+ *
+ * Used in fight mode to exclude pre-fight positions from display
+ */
+export function filterPositionsByBlockedSymbols<T extends PositionForFiltering>(
+  positions: T[],
+  blockedSymbols: string[]
+): T[] {
+  return positions.filter(pos => !blockedSymbols.includes(pos.symbol));
+}
+
+/**
+ * Position interface for leverage validation
+ */
+export interface PositionForLeverageValidation {
+  symbol: string;
+  leverage?: number;
+}
+
+/**
+ * Leverage validation result
+ */
+export interface LeverageValidation {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Validate leverage change against open positions
+ * Extracted from terminal logic (trade/page.tsx:271-288)
+ *
+ * Pacifica only allows INCREASING leverage on open positions
+ * Cannot decrease leverage below current position leverage
+ */
+export function validateLeverageChange(
+  newLeverage: number,
+  positions: PositionForLeverageValidation[],
+  symbol: string
+): LeverageValidation {
+  const marketSymbol = symbol.replace('-USD', '');
+  const openPosition = positions.find(
+    p => p.symbol.replace('-USD', '') === marketSymbol
+  );
+
+  if (openPosition) {
+    const positionLeverage = openPosition.leverage || 1;
+    // Pacifica only allows INCREASING leverage on open positions
+    if (newLeverage < positionLeverage) {
+      return {
+        valid: false,
+        error: `Cannot decrease leverage below ${positionLeverage}x while ${marketSymbol} position is open`
+      };
+    }
+  }
+
+  return { valid: true };
+}
+
+/**
+ * TP/SL parameters for order placement
+ */
+export interface TpSlParams {
+  tp?: { stop_price: string };
+  sl?: { stop_price: string };
+}
+
+/**
+ * Build TP/SL parameters for order placement
+ * Extracted from terminal logic (trade/page.tsx:340-345)
+ *
+ * Rounds prices to tick size to avoid "Invalid stop tick" errors from Pacifica
+ * Only includes params if enabled and price is provided
+ */
+export function buildTpSlParams(
+  orderType: string,
+  tpEnabled: boolean,
+  slEnabled: boolean,
+  takeProfit: string,
+  stopLoss: string,
+  tickSize: number
+): TpSlParams {
+  const params: TpSlParams = {};
+
+  // TP/SL only supported for market and limit orders
+  if (orderType === 'market' || orderType === 'limit') {
+    if (tpEnabled && takeProfit) {
+      params.tp = { stop_price: roundToTickSize(parseFloat(takeProfit), tickSize) };
+    }
+    if (slEnabled && stopLoss) {
+      params.sl = { stop_price: roundToTickSize(parseFloat(stopLoss), tickSize) };
+    }
+  }
+
+  return params;
+}


### PR DESCRIPTION
## Quick Positions Bar
- Add draggable carousel in navbar showing active positions with real-time PnL
- Display symbol, side (LONG/SHORT), PnL %, and current price
- Smart price formatting to prevent navbar jumping (handles 1-10K+ range)
- Fixed-width formatting for percentages to prevent layout shifts
- Dropdown view for mobile/compact mode
- Hide scrollbar while maintaining drag functionality

## Quick Position Modal
- Quick actions modal with 3 tabs: Close, TP/SL, Flip
- Close tab: adjust position size (25%, 50%, 75%, 100%) with slider
- TP/SL tab: set take profit and stop loss with preset percentage buttons
- Flip tab: close and reverse position in one action
- "Go to Terminal" button in all tabs to navigate to full trading page
- Margin-based percentage calculations matching TpSlModal behavior

## Settings System
- Add settings modal with toggles for Quick Bar, Balance Display, and Notifications
- Persistent settings stored in localStorage
- Custom events for cross-component communication
- Settings gear icon in sidebar

## Centralized Trading Utils (apps/web/src/lib/trading/utils.ts)
- Priority 1: Liquidation price calculation, TP/SL order filtering
- Priority 2: Lot size/tick size rounding, account stats, order amount calculation
- Priority 3: Position value calculations, margin/size conversions, TP/SL from leverage
- Priority 4: Position filtering, leverage validation, TP/SL params builder
- All 20+ functions extracted from trade/page.tsx for reusability

## UI/UX Improvements
- Sidebar toggle button: white background with black arrow when collapsed
- Navbar positions carousel with drag-to-scroll (no visible scrollbar)
- Fixed-width display for prices and percentages to prevent UI jumping
- Professional color scheme matching existing design system