### PR TITLE
feat: add Current Standing card and full-width responsive layout

### DIFF
--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -215,112 +215,187 @@ export default function LeaderboardPage() {
           <div className="animate-fadeIn">
             {/* Top 3 Podium - Card design like landing page but smaller (Weekly only) */}
             {range === 'weekly' && first && second && third && (
-              <div className="hidden md:grid grid-cols-3 gap-3 mb-6 max-w-3xl mx-auto items-end">
-                {/* 2nd Place */}
-                <div className="bg-gradient-to-b from-slate-400/20 to-slate-500/10 border border-slate-400/50 rounded-xl p-4">
-                  <div className="flex items-center gap-2 mb-3">
-                    <div className="w-7 h-7 rounded-full bg-slate-400/30 flex items-center justify-center">
-                      <span className="text-slate-300 text-xs font-bold">2</span>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-2 md:gap-3 mb-4 md:mb-6 max-w-3xl mx-auto md:items-end">
+                {/* 1st Place - Featured (shown first on mobile, middle on desktop) */}
+                <div className="bg-gradient-to-b from-amber-500/20 to-yellow-600/10 border border-amber-500/50 rounded-lg md:rounded-xl p-2.5 md:p-5 shadow-lg shadow-amber-500/10 md:order-2">
+                  <div className="flex items-center gap-1.5 md:gap-2 mb-2 md:mb-3">
+                    <div className="w-6 h-6 md:w-8 md:h-8 rounded-full bg-amber-500/30 flex items-center justify-center flex-shrink-0">
+                      <span className="text-amber-400 text-xs md:text-sm font-bold">1</span>
                     </div>
+                    <div className="min-w-0">
+                      <p className="text-amber-400 font-bold text-xs md:text-base truncate">1st Place</p>
+                      <p className="text-surface-500 text-[10px] md:text-xs">5% of fees</p>
+                    </div>
+                  </div>
+                  {/* Mobile: Compact horizontal layout */}
+                  <div className="flex md:hidden items-center justify-between gap-2">
                     <div>
-                      <p className="text-slate-300 font-semibold text-sm">2nd Place</p>
-                      <p className="text-surface-500 text-xs">3% of fees</p>
+                      <p className="text-surface-500 text-[10px] mb-0.5">Prize</p>
+                      <p className="font-bold text-gradient-orange text-base">
+                        {formatCurrency((prizePool?.totalFeesCollected || 0) * 0.05)}
+                      </p>
                     </div>
-                  </div>
-                  <div className="mb-3">
-                    <p className="text-surface-500 text-xs mb-0.5">Prize</p>
-                    <p className="font-bold text-gradient-orange text-xl">
-                      {formatCurrency((prizePool?.totalFeesCollected || 0) * 0.03)}
-                    </p>
-                  </div>
-                  <div className="border-t border-surface-800/50 pt-3">
-                    <p className="text-surface-500 text-[10px] mb-1.5 uppercase tracking-wide">Current Leader</p>
-                    <div className="flex items-center gap-2">
-                      <div className="avatar w-8 h-8 text-xs">{second.handle[0]?.toUpperCase() || '?'}</div>
-                      <div className="flex-1 min-w-0">
-                        <Link href={`/profile/${second.userId}`} className="text-white text-sm font-medium truncate block hover:text-primary-400">
-                          {second.handle}
-                        </Link>
-                        <div className="flex items-center gap-1.5 text-[10px]">
-                          <span className={second.totalPnlUsdc >= 0 ? 'text-win-400' : 'text-loss-400'}>
-                            {second.totalPnlUsdc >= 0 ? '+' : ''}{formatCurrency(second.totalPnlUsdc)} PnL
-                          </span>
-                          <span className="text-surface-500">•</span>
-                          <span className="text-surface-400">{second.wins}W {second.losses}L</span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                {/* 1st Place - Featured */}
-                <div className="bg-gradient-to-b from-amber-500/20 to-yellow-600/10 border border-amber-500/50 rounded-xl p-5 shadow-lg shadow-amber-500/10">
-                  <div className="flex items-center gap-2 mb-3">
-                    <div className="w-8 h-8 rounded-full bg-amber-500/30 flex items-center justify-center">
-                      <span className="text-amber-400 text-sm font-bold">1</span>
-                    </div>
-                    <div>
-                      <p className="text-amber-400 font-bold">1st Place</p>
-                      <p className="text-surface-500 text-xs">5% of fees</p>
-                    </div>
-                  </div>
-                  <div className="mb-4">
-                    <p className="text-surface-500 text-xs mb-0.5">Prize</p>
-                    <p className="font-bold text-gradient-orange text-2xl">
-                      {formatCurrency((prizePool?.totalFeesCollected || 0) * 0.05)}
-                    </p>
-                  </div>
-                  <div className="border-t border-surface-800/50 pt-3">
-                    <p className="text-surface-500 text-[10px] mb-1.5 uppercase tracking-wide">Current Leader</p>
-                    <div className="flex items-center gap-2">
-                      <div className="avatar w-9 h-9 text-sm">{first.handle[0]?.toUpperCase() || '?'}</div>
-                      <div className="flex-1 min-w-0">
-                        <Link href={`/profile/${first.userId}`} className="text-white font-semibold truncate block hover:text-primary-400">
+                    <div className="flex items-center gap-1.5">
+                      <div className="avatar w-6 h-6 text-[10px] flex-shrink-0">{first.handle[0]?.toUpperCase() || '?'}</div>
+                      <div className="min-w-0">
+                        <Link href={`/profile/${first.userId}`} className="text-white text-xs font-semibold truncate block hover:text-primary-400">
                           {first.handle}
                         </Link>
-                        <div className="flex items-center gap-1.5 text-xs">
+                        <div className="text-[9px]">
                           <span className={first.totalPnlUsdc >= 0 ? 'text-win-400' : 'text-loss-400'}>
-                            {first.totalPnlUsdc >= 0 ? '+' : ''}{formatCurrency(first.totalPnlUsdc)} PnL
+                            {first.totalPnlUsdc >= 0 ? '+' : ''}{formatCurrency(first.totalPnlUsdc)}
                           </span>
-                          <span className="text-surface-500">•</span>
-                          <span className="text-surface-400">{first.wins}W {first.losses}L</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  {/* Desktop: Original vertical layout */}
+                  <div className="hidden md:block">
+                    <div className="mb-4">
+                      <p className="text-surface-500 text-xs mb-0.5">Prize</p>
+                      <p className="font-bold text-gradient-orange text-2xl">
+                        {formatCurrency((prizePool?.totalFeesCollected || 0) * 0.05)}
+                      </p>
+                    </div>
+                    <div className="border-t border-surface-800/50 pt-3">
+                      <p className="text-surface-500 text-[10px] mb-1.5 uppercase tracking-wide">Current Leader</p>
+                      <div className="flex items-center gap-2">
+                        <div className="avatar w-9 h-9 text-sm flex-shrink-0">{first.handle[0]?.toUpperCase() || '?'}</div>
+                        <div className="flex-1 min-w-0">
+                          <Link href={`/profile/${first.userId}`} className="text-white text-base font-semibold truncate block hover:text-primary-400">
+                            {first.handle}
+                          </Link>
+                          <div className="flex items-center gap-1.5 text-xs">
+                            <span className={first.totalPnlUsdc >= 0 ? 'text-win-400' : 'text-loss-400'}>
+                              {first.totalPnlUsdc >= 0 ? '+' : ''}{formatCurrency(first.totalPnlUsdc)} PnL
+                            </span>
+                            <span className="text-surface-500">•</span>
+                            <span className="text-surface-400">{first.wins}W {first.losses}L</span>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
 
-                {/* 3rd Place */}
-                <div className="bg-gradient-to-b from-orange-700/20 to-amber-800/10 border border-orange-600/50 rounded-xl p-4">
-                  <div className="flex items-center gap-2 mb-3">
-                    <div className="w-7 h-7 rounded-full bg-orange-600/30 flex items-center justify-center">
-                      <span className="text-orange-400 text-xs font-bold">3</span>
+                {/* 2nd Place (shown second on mobile, first on desktop) */}
+                <div className="bg-gradient-to-b from-slate-400/20 to-slate-500/10 border border-slate-400/50 rounded-lg p-2.5 md:p-4 md:order-1">
+                  <div className="flex items-center gap-1.5 md:gap-2 mb-2 md:mb-3">
+                    <div className="w-6 h-6 md:w-7 md:h-7 rounded-full bg-slate-400/30 flex items-center justify-center flex-shrink-0">
+                      <span className="text-slate-300 text-[10px] md:text-xs font-bold">2</span>
                     </div>
+                    <div className="min-w-0">
+                      <p className="text-slate-300 font-semibold text-xs md:text-sm truncate">2nd Place</p>
+                      <p className="text-surface-500 text-[10px] md:text-xs">3% of fees</p>
+                    </div>
+                  </div>
+                  {/* Mobile: Compact horizontal layout */}
+                  <div className="flex md:hidden items-center justify-between gap-2">
                     <div>
-                      <p className="text-orange-400 font-semibold text-sm">3rd Place</p>
-                      <p className="text-surface-500 text-xs">2% of fees</p>
+                      <p className="text-surface-500 text-[10px] mb-0.5">Prize</p>
+                      <p className="font-bold text-gradient-orange text-sm">
+                        {formatCurrency((prizePool?.totalFeesCollected || 0) * 0.03)}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <div className="avatar w-5 h-5 text-[9px] flex-shrink-0">{second.handle[0]?.toUpperCase() || '?'}</div>
+                      <div className="min-w-0">
+                        <Link href={`/profile/${second.userId}`} className="text-white text-[10px] font-medium truncate block hover:text-primary-400">
+                          {second.handle}
+                        </Link>
+                        <div className="text-[9px]">
+                          <span className={second.totalPnlUsdc >= 0 ? 'text-win-400' : 'text-loss-400'}>
+                            {second.totalPnlUsdc >= 0 ? '+' : ''}{formatCurrency(second.totalPnlUsdc)}
+                          </span>
+                        </div>
+                      </div>
                     </div>
                   </div>
-                  <div className="mb-3">
-                    <p className="text-surface-500 text-xs mb-0.5">Prize</p>
-                    <p className="font-bold text-gradient-orange text-xl">
-                      {formatCurrency((prizePool?.totalFeesCollected || 0) * 0.02)}
-                    </p>
+                  {/* Desktop: Original vertical layout */}
+                  <div className="hidden md:block">
+                    <div className="mb-3">
+                      <p className="text-surface-500 text-xs mb-0.5">Prize</p>
+                      <p className="font-bold text-gradient-orange text-xl">
+                        {formatCurrency((prizePool?.totalFeesCollected || 0) * 0.03)}
+                      </p>
+                    </div>
+                    <div className="border-t border-surface-800/50 pt-3">
+                      <p className="text-surface-500 text-[10px] mb-1.5 uppercase tracking-wide">Current Leader</p>
+                      <div className="flex items-center gap-2">
+                        <div className="avatar w-8 h-8 text-xs flex-shrink-0">{second.handle[0]?.toUpperCase() || '?'}</div>
+                        <div className="flex-1 min-w-0">
+                          <Link href={`/profile/${second.userId}`} className="text-white text-sm font-medium truncate block hover:text-primary-400">
+                            {second.handle}
+                          </Link>
+                          <div className="flex items-center gap-1.5 text-[10px]">
+                            <span className={second.totalPnlUsdc >= 0 ? 'text-win-400' : 'text-loss-400'}>
+                              {second.totalPnlUsdc >= 0 ? '+' : ''}{formatCurrency(second.totalPnlUsdc)} PnL
+                            </span>
+                            <span className="text-surface-500">•</span>
+                            <span className="text-surface-400">{second.wins}W {second.losses}L</span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </div>
-                  <div className="border-t border-surface-800/50 pt-3">
-                    <p className="text-surface-500 text-[10px] mb-1.5 uppercase tracking-wide">Current Leader</p>
-                    <div className="flex items-center gap-2">
-                      <div className="avatar w-8 h-8 text-xs">{third.handle[0]?.toUpperCase() || '?'}</div>
-                      <div className="flex-1 min-w-0">
-                        <Link href={`/profile/${third.userId}`} className="text-white text-sm font-medium truncate block hover:text-primary-400">
+                </div>
+
+                {/* 3rd Place (shown third on mobile, third on desktop) */}
+                <div className="bg-gradient-to-b from-orange-700/20 to-amber-800/10 border border-orange-600/50 rounded-lg p-2.5 md:p-4 md:order-3">
+                  <div className="flex items-center gap-1.5 md:gap-2 mb-2 md:mb-3">
+                    <div className="w-6 h-6 md:w-7 md:h-7 rounded-full bg-orange-600/30 flex items-center justify-center flex-shrink-0">
+                      <span className="text-orange-400 text-[10px] md:text-xs font-bold">3</span>
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-orange-400 font-semibold text-xs md:text-sm truncate">3rd Place</p>
+                      <p className="text-surface-500 text-[10px] md:text-xs">2% of fees</p>
+                    </div>
+                  </div>
+                  {/* Mobile: Compact horizontal layout */}
+                  <div className="flex md:hidden items-center justify-between gap-2">
+                    <div>
+                      <p className="text-surface-500 text-[10px] mb-0.5">Prize</p>
+                      <p className="font-bold text-gradient-orange text-sm">
+                        {formatCurrency((prizePool?.totalFeesCollected || 0) * 0.02)}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <div className="avatar w-5 h-5 text-[9px] flex-shrink-0">{third.handle[0]?.toUpperCase() || '?'}</div>
+                      <div className="min-w-0">
+                        <Link href={`/profile/${third.userId}`} className="text-white text-[10px] font-medium truncate block hover:text-primary-400">
                           {third.handle}
                         </Link>
-                        <div className="flex items-center gap-1.5 text-[10px]">
+                        <div className="text-[9px]">
                           <span className={third.totalPnlUsdc >= 0 ? 'text-win-400' : 'text-loss-400'}>
-                            {third.totalPnlUsdc >= 0 ? '+' : ''}{formatCurrency(third.totalPnlUsdc)} PnL
+                            {third.totalPnlUsdc >= 0 ? '+' : ''}{formatCurrency(third.totalPnlUsdc)}
                           </span>
-                          <span className="text-surface-500">•</span>
-                          <span className="text-surface-400">{third.wins}W {third.losses}L</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  {/* Desktop: Original vertical layout */}
+                  <div className="hidden md:block">
+                    <div className="mb-3">
+                      <p className="text-surface-500 text-xs mb-0.5">Prize</p>
+                      <p className="font-bold text-gradient-orange text-xl">
+                        {formatCurrency((prizePool?.totalFeesCollected || 0) * 0.02)}
+                      </p>
+                    </div>
+                    <div className="border-t border-surface-800/50 pt-3">
+                      <p className="text-surface-500 text-[10px] mb-1.5 uppercase tracking-wide">Current Leader</p>
+                      <div className="flex items-center gap-2">
+                        <div className="avatar w-8 h-8 text-xs flex-shrink-0">{third.handle[0]?.toUpperCase() || '?'}</div>
+                        <div className="flex-1 min-w-0">
+                          <Link href={`/profile/${third.userId}`} className="text-white text-sm font-medium truncate block hover:text-primary-400">
+                            {third.handle}
+                          </Link>
+                          <div className="flex items-center gap-1.5 text-[10px]">
+                            <span className={third.totalPnlUsdc >= 0 ? 'text-win-400' : 'text-loss-400'}>
+                              {third.totalPnlUsdc >= 0 ? '+' : ''}{formatCurrency(third.totalPnlUsdc)} PnL
+                            </span>
+                            <span className="text-surface-500">•</span>
+                            <span className="text-surface-400">{third.wins}W {third.losses}L</span>
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/apps/web/src/app/referrals/page.tsx
+++ b/apps/web/src/app/referrals/page.tsx
@@ -33,6 +33,10 @@ export default function ReferralsPage() {
   }, [searchParams]);
 
   const [activeTab, setActiveTabState] = useState<ReferralTab>(getTabFromUrl);
+  const [earningsToShow, setEarningsToShow] = useState(10);
+  const [recentReferralsToShow, setRecentReferralsToShow] = useState(10);
+  const [allReferralsToShow, setAllReferralsToShow] = useState(10);
+  const [payoutsToShow, setPayoutsToShow] = useState(10);
 
   // Update URL when tab changes
   const setActiveTab = useCallback((tab: ReferralTab) => {
@@ -272,24 +276,26 @@ export default function ReferralsPage() {
                 Your Referral Code
               </h2>
               <div className="bg-surface-900 rounded-lg p-4 mb-4 border border-surface-800">
-                <p className="text-2xl font-mono font-bold text-primary-400 text-center tracking-wider">
+                <p className="text-lg sm:text-2xl font-mono font-bold text-primary-400 text-center tracking-wider break-all">
                   {dashboard.referralCode}
                 </p>
               </div>
               <div className="flex gap-2">
                 <button
                   onClick={handleCopyCode}
-                  className="flex-1 btn-secondary text-sm py-2 flex items-center justify-center gap-2"
+                  className="flex-1 btn-secondary text-xs sm:text-sm py-2 flex items-center justify-center gap-1 sm:gap-2"
                 >
                   <ContentCopyIcon sx={{ fontSize: 18 }} />
-                  Copy Code
+                  <span className="hidden xs:inline">Copy Code</span>
+                  <span className="xs:hidden">Code</span>
                 </button>
                 <button
                   onClick={handleCopyLink}
-                  className="flex-1 btn-primary text-sm py-2 flex items-center justify-center gap-2"
+                  className="flex-1 btn-primary text-xs sm:text-sm py-2 flex items-center justify-center gap-1 sm:gap-2"
                 >
                   <ShareIcon sx={{ fontSize: 18 }} />
-                  Copy Link
+                  <span className="hidden xs:inline">Copy Link</span>
+                  <span className="xs:hidden">Link</span>
                 </button>
               </div>
             </div>
@@ -422,39 +428,52 @@ export default function ReferralsPage() {
                     <p className="text-surface-500 text-sm">No referrals yet</p>
                   </div>
                 ) : (
-                  <div className="overflow-x-auto">
-                    <table className="table-premium w-full">
-                      <thead>
-                        <tr className="bg-surface-850">
-                          <th className="py-3 px-4 text-left text-xs font-medium text-surface-400">User</th>
-                          <th className="py-3 px-4 text-center text-xs font-medium text-surface-400">Tier</th>
-                          <th className="py-3 px-4 text-right text-xs font-medium text-surface-400">Joined</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {dashboard.recentReferrals.map((ref, index) => (
-                          <tr key={ref.id} className={`transition-colors ${index % 2 === 0 ? 'bg-surface-800/30' : ''} hover:bg-surface-800/50`}>
-                            <td className="py-3 px-4">
-                              <div className="flex items-center gap-2">
-                                <div className="avatar w-8 h-8 text-xs">
-                                  {ref.user.handle[0]?.toUpperCase() || '?'}
-                                </div>
-                                <span className="text-white text-sm">{ref.user.handle}</span>
-                              </div>
-                            </td>
-                            <td className="py-3 px-4 text-center">
-                              <span className="px-2 py-1 rounded bg-primary-500/10 text-primary-400 text-xs font-medium">
-                                T{ref.tier}
-                              </span>
-                            </td>
-                            <td className="py-3 px-4 text-right text-surface-400 text-sm">
-                              {new Date(ref.joinedAt).toLocaleDateString()}
-                            </td>
+                  <>
+                    <div className="overflow-x-auto">
+                      <table className="table-premium w-full">
+                        <thead>
+                          <tr className="bg-surface-850">
+                            <th className="py-3 px-4 text-left text-xs font-medium text-surface-400">User</th>
+                            <th className="py-3 px-4 text-center text-xs font-medium text-surface-400">Tier</th>
+                            <th className="py-3 px-4 text-right text-xs font-medium text-surface-400">Joined</th>
                           </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
+                        </thead>
+                        <tbody>
+                          {dashboard.recentReferrals.slice(0, recentReferralsToShow).map((ref, index) => (
+                            <tr key={ref.id} className={`transition-colors ${index % 2 === 0 ? 'bg-surface-800/30' : ''} hover:bg-surface-800/50`}>
+                              <td className="py-3 px-4">
+                                <div className="flex items-center gap-2">
+                                  <div className="avatar w-8 h-8 text-xs">
+                                    {ref.user.handle[0]?.toUpperCase() || '?'}
+                                  </div>
+                                  <span className="text-white text-sm">{ref.user.handle}</span>
+                                </div>
+                              </td>
+                              <td className="py-3 px-4 text-center">
+                                <span className="px-2 py-1 rounded bg-primary-500/10 text-primary-400 text-xs font-medium">
+                                  T{ref.tier}
+                                </span>
+                              </td>
+                              <td className="py-3 px-4 text-right text-surface-400 text-sm">
+                                {new Date(ref.joinedAt).toLocaleDateString()}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                    {/* Load More Button */}
+                    {dashboard.recentReferrals.length > recentReferralsToShow && (
+                      <div className="py-4 text-center border-t border-surface-800/50">
+                        <button
+                          onClick={() => setRecentReferralsToShow(prev => prev + 10)}
+                          className="text-sm text-primary-400 hover:text-primary-300 transition-colors"
+                        >
+                          Load More ({recentReferralsToShow} of {dashboard.recentReferrals.length} referrals)
+                        </button>
+                      </div>
+                    )}
+                  </>
                 )}
               </div>
 
@@ -471,48 +490,61 @@ export default function ReferralsPage() {
                     <p className="text-surface-500 text-sm">No earnings yet</p>
                   </div>
                 ) : (
-                  <div className="overflow-x-auto">
-                    <table className="table-premium w-full">
-                      <thead>
-                        <tr className="bg-surface-850">
-                          <th className="py-3 px-4 text-left text-xs font-medium text-surface-400">Symbol</th>
-                          <th className="py-3 px-4 text-center text-xs font-medium text-surface-400">Tier</th>
-                          <th className="py-3 px-4 text-right text-xs font-medium text-surface-400">Amount</th>
-                          <th className="py-3 px-4 text-center text-xs font-medium text-surface-400">Status</th>
-                          <th className="py-3 px-4 text-right text-xs font-medium text-surface-400">Date</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {dashboard.recentEarnings.map((earning, index) => (
-                          <tr key={earning.id} className={`transition-colors ${index % 2 === 0 ? 'bg-surface-800/30' : ''} hover:bg-surface-800/50`}>
-                            <td className="py-3 px-4 text-white font-medium">{earning.symbol}</td>
-                            <td className="py-3 px-4 text-center">
-                              <span className="px-2 py-1 rounded bg-primary-500/10 text-primary-400 text-xs font-medium">
-                                T{earning.tier}
-                              </span>
-                            </td>
-                            <td className="py-3 px-4 text-right text-win-400 font-medium">
-                              ${Number(earning.commissionAmount).toFixed(2)}
-                            </td>
-                            <td className="py-3 px-4 text-center">
-                              <span
-                                className={`px-2 py-1 rounded text-xs font-medium ${
-                                  earning.isPaid
-                                    ? 'bg-win-500/10 text-win-400'
-                                    : 'bg-surface-700 text-surface-400'
-                                }`}
-                              >
-                                {earning.isPaid ? 'Paid' : 'Pending'}
-                              </span>
-                            </td>
-                            <td className="py-3 px-4 text-right text-surface-400 text-sm">
-                              {new Date(earning.earnedAt).toLocaleDateString()}
-                            </td>
+                  <>
+                    <div className="overflow-x-auto">
+                      <table className="table-premium w-full">
+                        <thead>
+                          <tr className="bg-surface-850">
+                            <th className="py-3 px-4 text-left text-xs font-medium text-surface-400">Symbol</th>
+                            <th className="py-3 px-4 text-center text-xs font-medium text-surface-400">Tier</th>
+                            <th className="py-3 px-4 text-right text-xs font-medium text-surface-400">Amount</th>
+                            <th className="py-3 px-4 text-center text-xs font-medium text-surface-400">Status</th>
+                            <th className="py-3 px-4 text-right text-xs font-medium text-surface-400">Date</th>
                           </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
+                        </thead>
+                        <tbody>
+                          {dashboard.recentEarnings.slice(0, earningsToShow).map((earning, index) => (
+                            <tr key={earning.id} className={`transition-colors ${index % 2 === 0 ? 'bg-surface-800/30' : ''} hover:bg-surface-800/50`}>
+                              <td className="py-3 px-4 text-white font-medium">{earning.symbol}</td>
+                              <td className="py-3 px-4 text-center">
+                                <span className="px-2 py-1 rounded bg-primary-500/10 text-primary-400 text-xs font-medium">
+                                  T{earning.tier}
+                                </span>
+                              </td>
+                              <td className="py-3 px-4 text-right text-win-400 font-medium">
+                                ${Number(earning.commissionAmount).toFixed(2)}
+                              </td>
+                              <td className="py-3 px-4 text-center">
+                                <span
+                                  className={`px-2 py-1 rounded text-xs font-medium ${
+                                    earning.isPaid
+                                      ? 'bg-win-500/10 text-win-400'
+                                      : 'bg-surface-700 text-surface-400'
+                                  }`}
+                                >
+                                  {earning.isPaid ? 'Paid' : 'Pending'}
+                                </span>
+                              </td>
+                              <td className="py-3 px-4 text-right text-surface-400 text-sm">
+                                {new Date(earning.earnedAt).toLocaleDateString()}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                    {/* Load More Button */}
+                    {dashboard.recentEarnings.length > earningsToShow && (
+                      <div className="py-4 text-center border-t border-surface-800/50">
+                        <button
+                          onClick={() => setEarningsToShow(prev => prev + 10)}
+                          className="text-sm text-primary-400 hover:text-primary-300 transition-colors"
+                        >
+                          Load More ({earningsToShow} of {dashboard.recentEarnings.length} earnings)
+                        </button>
+                      </div>
+                    )}
+                  </>
                 )}
               </div>
             </div>
@@ -532,54 +564,62 @@ export default function ReferralsPage() {
                   <p className="text-surface-600 text-xs mt-2">Share your referral link to start earning commissions</p>
                 </div>
               ) : (
-                <div className="overflow-x-auto">
-                  <table className="table-premium w-full">
-                    <thead>
-                      <tr className="bg-surface-850">
-                        <th className="py-3 px-4 text-left text-xs font-medium text-surface-400">User</th>
-                        <th className="py-3 px-4 text-center text-xs font-medium text-surface-400">Tier</th>
-                        <th className="py-3 px-4 text-center text-xs font-medium text-surface-400">Commission</th>
-                        <th className="py-3 px-4 text-right text-xs font-medium text-surface-400">Joined</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {dashboard.recentReferrals.map((ref, index) => (
-                        <tr key={ref.id} className={`transition-colors ${index % 2 === 0 ? 'bg-surface-800/30' : ''} hover:bg-surface-800/50`}>
-                          <td className="py-3 px-4">
-                            <div className="flex items-center gap-2">
-                              <div className="avatar w-8 h-8 text-xs">
-                                {ref.user.handle[0]?.toUpperCase() || '?'}
-                              </div>
-                              <div>
-                                <span className="text-white text-sm block">{ref.user.handle}</span>
-                                <span className="text-surface-500 text-xs font-mono">
-                                  {ref.user.walletAddress ? `${ref.user.walletAddress.slice(0, 4)}...${ref.user.walletAddress.slice(-4)}` : '-'}
-                                </span>
-                              </div>
-                            </div>
-                          </td>
-                          <td className="py-3 px-4 text-center">
-                            <span className={`px-2 py-1 rounded text-xs font-medium ${
-                              ref.tier === 1 ? 'bg-primary-500/10 text-primary-400' :
-                              ref.tier === 2 ? 'bg-violet-500/10 text-violet-400' :
-                              'bg-surface-700 text-surface-400'
-                            }`}>
-                              T{ref.tier}
-                            </span>
-                          </td>
-                          <td className="py-3 px-4 text-center text-surface-300 text-sm">
-                            {ref.tier === 1 ? dashboard.commissionRates.t1 :
-                             ref.tier === 2 ? dashboard.commissionRates.t2 :
-                             dashboard.commissionRates.t3}%
-                          </td>
-                          <td className="py-3 px-4 text-right text-surface-400 text-sm">
-                            {new Date(ref.joinedAt).toLocaleDateString()}
-                          </td>
+                <>
+                  <div className="overflow-x-auto">
+                    <table className="table-premium w-full">
+                      <thead>
+                        <tr className="bg-surface-850">
+                          <th className="py-3 px-4 text-left text-xs font-medium text-surface-400">User</th>
+                          <th className="py-3 px-4 text-center text-xs font-medium text-surface-400">Tier</th>
+                          <th className="py-3 px-4 text-center text-xs font-medium text-surface-400">Commission</th>
+                          <th className="py-3 px-4 text-right text-xs font-medium text-surface-400">Joined</th>
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                      </thead>
+                      <tbody>
+                        {dashboard.recentReferrals.slice(0, allReferralsToShow).map((ref, index) => (
+                          <tr key={ref.id} className={`transition-colors ${index % 2 === 0 ? 'bg-surface-800/30' : ''} hover:bg-surface-800/50`}>
+                            <td className="py-3 px-4">
+                              <div className="flex items-center gap-2">
+                                <div className="avatar w-8 h-8 text-xs">
+                                  {ref.user.handle[0]?.toUpperCase() || '?'}
+                                </div>
+                                <span className="text-white text-sm">{ref.user.handle}</span>
+                              </div>
+                            </td>
+                            <td className="py-3 px-4 text-center">
+                              <span className={`px-2 py-1 rounded text-xs font-medium ${
+                                ref.tier === 1 ? 'bg-primary-500/10 text-primary-400' :
+                                ref.tier === 2 ? 'bg-violet-500/10 text-violet-400' :
+                                'bg-surface-700 text-surface-400'
+                              }`}>
+                                T{ref.tier}
+                              </span>
+                            </td>
+                            <td className="py-3 px-4 text-center text-surface-300 text-sm">
+                              {ref.tier === 1 ? dashboard.commissionRates.t1 :
+                               ref.tier === 2 ? dashboard.commissionRates.t2 :
+                               dashboard.commissionRates.t3}%
+                            </td>
+                            <td className="py-3 px-4 text-right text-surface-400 text-sm">
+                              {new Date(ref.joinedAt).toLocaleDateString()}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                  {/* Load More Button */}
+                  {dashboard.recentReferrals.length > allReferralsToShow && (
+                    <div className="py-4 text-center border-t border-surface-800/50">
+                      <button
+                        onClick={() => setAllReferralsToShow(prev => prev + 10)}
+                        className="text-sm text-primary-400 hover:text-primary-300 transition-colors"
+                      >
+                        Load More ({allReferralsToShow} of {dashboard.recentReferrals.length} referrals)
+                      </button>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           )}
@@ -597,63 +637,76 @@ export default function ReferralsPage() {
                   <p className="text-surface-500 text-sm">No payouts yet</p>
                 </div>
               ) : (
-                <div className="overflow-x-auto">
-                  <table className="table-premium w-full">
-                    <thead>
-                      <tr className="bg-surface-850">
-                        <th className="py-3 px-4 text-left text-xs font-medium text-surface-400">Date</th>
-                        <th className="py-3 px-4 text-right text-xs font-medium text-surface-400">Amount</th>
-                        <th className="py-3 px-4 text-center text-xs font-medium text-surface-400">Status</th>
-                        <th className="py-3 px-4 text-left text-xs font-medium text-surface-400">Tx Signature</th>
-                        <th className="py-3 px-4 text-left text-xs font-medium text-surface-400">Wallet</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {dashboard.payoutHistory.map((payout, index) => (
-                        <tr key={payout.id} className={`transition-colors ${index % 2 === 0 ? 'bg-surface-800/30' : ''} hover:bg-surface-800/50`}>
-                          <td className="py-3 px-4 text-surface-400 text-sm">
-                            {new Date(payout.createdAt).toLocaleDateString()}
-                          </td>
-                          <td className="py-3 px-4 text-right text-white font-medium">
-                            ${Number(payout.amount).toFixed(2)}
-                          </td>
-                          <td className="py-3 px-4 text-center">
-                            <span
-                              className={`px-2 py-1 rounded text-xs font-medium ${
-                                payout.status === 'completed'
-                                  ? 'bg-win-500/10 text-win-400'
-                                  : payout.status === 'processing'
-                                  ? 'bg-accent-500/10 text-accent-400'
-                                  : payout.status === 'failed'
-                                  ? 'bg-loss-500/10 text-loss-400'
-                                  : 'bg-surface-700 text-surface-400'
-                              }`}
-                            >
-                              {payout.status}
-                            </span>
-                          </td>
-                          <td className="py-3 px-4 text-surface-400 text-sm font-mono">
-                            {payout.txSignature ? (
-                              <a
-                                href={`https://solscan.io/tx/${payout.txSignature}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="hover:text-primary-400 transition-colors"
-                              >
-                                {payout.txSignature.slice(0, 4)}...{payout.txSignature.slice(-4)}
-                              </a>
-                            ) : (
-                              <span className="text-surface-500">-</span>
-                            )}
-                          </td>
-                          <td className="py-3 px-4 text-surface-400 text-sm font-mono">
-                            {payout.walletAddress.slice(0, 8)}...{payout.walletAddress.slice(-6)}
-                          </td>
+                <>
+                  <div className="overflow-x-auto">
+                    <table className="table-premium w-full">
+                      <thead>
+                        <tr className="bg-surface-850">
+                          <th className="py-3 px-4 text-left text-xs font-medium text-surface-400">Date</th>
+                          <th className="py-3 px-4 text-right text-xs font-medium text-surface-400">Amount</th>
+                          <th className="py-3 px-4 text-center text-xs font-medium text-surface-400">Status</th>
+                          <th className="py-3 px-4 text-left text-xs font-medium text-surface-400">Tx Signature</th>
+                          <th className="py-3 px-4 text-left text-xs font-medium text-surface-400">Wallet</th>
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                      </thead>
+                      <tbody>
+                        {dashboard.payoutHistory.slice(0, payoutsToShow).map((payout, index) => (
+                          <tr key={payout.id} className={`transition-colors ${index % 2 === 0 ? 'bg-surface-800/30' : ''} hover:bg-surface-800/50`}>
+                            <td className="py-3 px-4 text-surface-400 text-sm">
+                              {new Date(payout.createdAt).toLocaleDateString()}
+                            </td>
+                            <td className="py-3 px-4 text-right text-white font-medium">
+                              ${Number(payout.amount).toFixed(2)}
+                            </td>
+                            <td className="py-3 px-4 text-center">
+                              <span
+                                className={`px-2 py-1 rounded text-xs font-medium ${
+                                  payout.status === 'completed'
+                                    ? 'bg-win-500/10 text-win-400'
+                                    : payout.status === 'processing'
+                                    ? 'bg-accent-500/10 text-accent-400'
+                                    : payout.status === 'failed'
+                                    ? 'bg-loss-500/10 text-loss-400'
+                                    : 'bg-surface-700 text-surface-400'
+                                }`}
+                              >
+                                {payout.status}
+                              </span>
+                            </td>
+                            <td className="py-3 px-4 text-surface-400 text-sm font-mono">
+                              {payout.txSignature ? (
+                                <a
+                                  href={`https://solscan.io/tx/${payout.txSignature}`}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="hover:text-primary-400 transition-colors"
+                                >
+                                  {payout.txSignature.slice(0, 4)}...{payout.txSignature.slice(-4)}
+                                </a>
+                              ) : (
+                                <span className="text-surface-500">-</span>
+                              )}
+                            </td>
+                            <td className="py-3 px-4 text-surface-400 text-sm font-mono">
+                              {payout.walletAddress.slice(0, 8)}...{payout.walletAddress.slice(-6)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                  {/* Load More Button */}
+                  {dashboard.payoutHistory.length > payoutsToShow && (
+                    <div className="py-4 text-center border-t border-surface-800/50">
+                      <button
+                        onClick={() => setPayoutsToShow(prev => prev + 10)}
+                        className="text-sm text-primary-400 hover:text-primary-300 transition-colors"
+                      >
+                        Load More ({payoutsToShow} of {dashboard.payoutHistory.length} payouts)
+                      </button>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           )}

--- a/apps/web/src/components/NotificationBell.tsx
+++ b/apps/web/src/components/NotificationBell.tsx
@@ -228,7 +228,7 @@ export function NotificationBell() {
 
       {/* Dropdown */}
       {isOpen && (
-        <div className="fixed sm:absolute right-4 sm:right-0 top-14 sm:top-full sm:mt-2 w-[calc(100vw-32px)] sm:w-80 bg-surface-900 border border-surface-800 rounded-lg shadow-2xl z-50 overflow-hidden">
+        <div className="fixed sm:absolute left-4 sm:right-0 sm:left-auto top-14 sm:top-full sm:mt-2 w-[calc(100vw-32px)] sm:w-80 bg-surface-900 border border-surface-800 rounded-lg shadow-2xl z-50 overflow-hidden">
           {/* Header */}
           <div className="p-3 border-b border-surface-800 flex justify-between items-center bg-surface-900">
             <span className="font-semibold text-white text-sm">Notifications</span>

--- a/apps/web/src/components/Positions.tsx
+++ b/apps/web/src/components/Positions.tsx
@@ -345,7 +345,7 @@ export function Positions({ positions, onClosePosition, onSetTpSl, onCancelOrder
                 <div className="flex items-center gap-2">
                   <span className="font-medium text-white">{getTokenSymbol(pos.symbol)}</span>
                   <span
-                    className={`px-1.5 py-0.5 rounded text-xs font-semibold ${
+                    className={`px-1.5 py-0.5 rounded text-[10px] sm:text-xs max-[1199px]:text-[10px] font-semibold ${
                       pos.side === 'LONG'
                         ? 'bg-win-500/20 text-win-400'
                         : 'bg-loss-500/20 text-loss-400'

--- a/apps/web/src/components/QuickPositionsBar.tsx
+++ b/apps/web/src/components/QuickPositionsBar.tsx
@@ -265,7 +265,7 @@ export function QuickPositionsDropdown() {
 
         {/* Dropdown menu */}
         {showDropdown && (
-          <div className="absolute top-full right-0 mt-2 w-80 bg-surface-850 rounded-lg shadow-xl border border-surface-800 overflow-hidden z-50">
+          <div className="fixed sm:absolute left-4 sm:right-0 sm:left-auto top-14 sm:top-full sm:mt-2 w-[calc(100vw-32px)] sm:w-80 bg-surface-850 rounded-lg shadow-xl border border-surface-800 overflow-hidden z-50">
             {positions.map((position: Position) => {
               const symbol = position.symbol;
               const symbolBase = symbol.replace('-USD', '');


### PR DESCRIPTION
- Add Current Standing card to Rewards page showing user's weekly rank and estimated prize
- Fix user ID reference: use user.id instead of user.userId
- Fix prize pool API endpoint: /api/prize-pool instead of /api/prize/pool
- Redesign card layout: rank badge in top-right, prize amount as main element
- Implement full-width layout for Rewards, Leaderboard, and Referrals pages
- Use 2xl: breakpoint (1536px) for responsive behavior
- Override container max-width with max-w-full pattern