### PR TITLE
fix: iOS wallet detection and mobile session persistence

### DIFF
--- a/apps/web/src/components/WalletProvider.tsx
+++ b/apps/web/src/components/WalletProvider.tsx
@@ -17,7 +17,7 @@ import { getDeviceContext, type DeviceContext } from '@/lib/mobile';
 // Import wallet adapter styles
 import '@solana/wallet-adapter-react-ui/styles.css';
 
-// Detectar contexto del dispositivo (desktop, mobile-browser, phantom-browser)
+// Detectar contexto del dispositivo (desktop, ios-mobile-browser, android-mobile-browser, phantom-browser)
 function useDeviceContext() {
   const [context, setContext] = useState<DeviceContext>('desktop');
 
@@ -63,7 +63,7 @@ export function WalletProviderWrapper({ children }: { children: ReactNode }) {
   // AutoConnect logic:
   // - Desktop: always autoConnect
   // - Phantom browser: always autoConnect (provider is injected)
-  // - Mobile browser: only autoConnect if user was previously authenticated
+  // - Mobile browser (iOS/Android): only autoConnect if user was previously authenticated
   const shouldAutoConnect = deviceContext === 'desktop' || deviceContext === 'phantom-browser' || hasPreviousAuth;
 
   // Use devnet by default, can be changed via environment variable
@@ -92,8 +92,14 @@ export function WalletProviderWrapper({ children }: { children: ReactNode }) {
       return [new PhantomWalletAdapter()];
     }
 
-    if (deviceContext === 'mobile-browser') {
-      // Regular mobile browser: use Mobile Wallet Adapter for deep linking
+    if (deviceContext === 'ios-mobile-browser') {
+      // iOS Safari/Chrome: PhantomWalletAdapter handles redirect to Phantom's in-app browser
+      // SolanaMobileWalletAdapter does NOT work on iOS (requires Android MWA protocol)
+      return [new PhantomWalletAdapter()];
+    }
+
+    if (deviceContext === 'android-mobile-browser') {
+      // Android mobile browser: use Mobile Wallet Adapter for deep linking
       const cluster = (process.env.NEXT_PUBLIC_SOLANA_NETWORK as 'devnet' | 'mainnet-beta') || 'devnet';
       return [
         new SolanaMobileWalletAdapter({

--- a/apps/web/src/lib/mobile.ts
+++ b/apps/web/src/lib/mobile.ts
@@ -12,6 +12,17 @@ export function isMobileDevice(): boolean {
 }
 
 /**
+ * Check if the current device is iOS (iPhone/iPad/iPod)
+ * SolanaMobileWalletAdapter does NOT work on iOS - only Android.
+ * On iOS, PhantomWalletAdapter handles the redirect to Phantom's in-app browser.
+ */
+export function isIOSDevice(): boolean {
+  if (typeof window === 'undefined') return false;
+  const ua = navigator.userAgent;
+  return /iPhone|iPad|iPod/i.test(ua) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+}
+
+/**
  * Check if we're running inside Phantom's dApp browser
  * Phantom injects window.phantom.solana when running inside their browser
  */
@@ -31,8 +42,12 @@ export function isPhantomBrowser(): boolean {
 
 /**
  * Get the device context for wallet configuration
+ * - desktop: browser extensions (Phantom, Solflare)
+ * - phantom-browser: inside Phantom's dApp browser (provider injected)
+ * - ios-mobile-browser: iOS Safari/Chrome - needs PhantomWalletAdapter (redirects to Phantom app)
+ * - android-mobile-browser: Android browser - can use SolanaMobileWalletAdapter
  */
-export type DeviceContext = 'desktop' | 'mobile-browser' | 'phantom-browser';
+export type DeviceContext = 'desktop' | 'ios-mobile-browser' | 'android-mobile-browser' | 'phantom-browser';
 
 export function getDeviceContext(): DeviceContext {
   if (typeof window === 'undefined') return 'desktop';
@@ -45,7 +60,11 @@ export function getDeviceContext(): DeviceContext {
     return 'phantom-browser';
   }
 
-  return 'mobile-browser';
+  if (isIOSDevice()) {
+    return 'ios-mobile-browser';
+  }
+
+  return 'android-mobile-browser';
 }
 
 /**


### PR DESCRIPTION
- Add iOS device detection to use PhantomWalletAdapter instead of SolanaMobileWalletAdapter (which only works on Android)
- Split mobile-browser context into ios-mobile-browser and android-mobile-browser for proper wallet adapter selection
- Add visibility/focus listeners to detect wallet changes when app returns from background (fixes stale session on Android/Phantom)