### PR TITLE
Enforce max 14px mobile text, fix horizontal scroll and wallet/balanc…

### DIFF
--- a/apps/web/src/app/fight/[id]/page.tsx
+++ b/apps/web/src/app/fight/[id]/page.tsx
@@ -171,7 +171,7 @@ export default function FightResultsPage() {
       <BetaGate>
         <div className="min-h-screen bg-surface-900 flex items-center justify-center text-white">
           <div className="text-center">
-            <p className="text-xl mb-4 text-surface-400">{error || 'Fight not found'}</p>
+            <p className="text-sm sm:text-xl mb-4 text-surface-400">{error || 'Fight not found'}</p>
             <Link href="/trade" className="btn-primary">
               Back to Lobby
             </Link>
@@ -306,7 +306,7 @@ export default function FightResultsPage() {
         <div className="text-center mb-8">
           {fight.status === 'NO_CONTEST' ? (
             <>
-              <h1 className="text-lg sm:text-4xl font-display font-bold text-amber-400 mb-2">
+              <h1 className="text-sm sm:text-4xl font-display font-bold text-amber-400 mb-2">
                 NO CONTEST
               </h1>
               <p className="text-surface-400">
@@ -330,14 +330,14 @@ export default function FightResultsPage() {
             </>
           ) : fight.isDraw ? (
             <>
-              <h1 className="text-lg sm:text-4xl font-display font-bold text-surface-300 mb-2">
+              <h1 className="text-sm sm:text-4xl font-display font-bold text-surface-300 mb-2">
                 DRAW
               </h1>
               <p className="text-surface-400">Both traders finished with equal performance</p>
             </>
           ) : fight.status === 'CANCELLED' ? (
             <>
-              <h1 className="text-lg sm:text-4xl font-display font-bold text-loss-400 mb-2">
+              <h1 className="text-sm sm:text-4xl font-display font-bold text-loss-400 mb-2">
                 CANCELLED
               </h1>
               <p className="text-surface-400">This fight was cancelled</p>
@@ -345,14 +345,14 @@ export default function FightResultsPage() {
           ) : isCurrentUserParticipant ? (
             isCurrentUserWinner ? (
               <>
-                <h1 className="text-lg sm:text-4xl font-display font-bold text-win-400 mb-2">
+                <h1 className="text-sm sm:text-4xl font-display font-bold text-win-400 mb-2">
                   VICTORY!
                 </h1>
                 <p className="text-surface-400">Congratulations, you won this fight!</p>
               </>
             ) : (
               <>
-                <h1 className="text-lg sm:text-4xl font-display font-bold text-loss-400 mb-2">
+                <h1 className="text-sm sm:text-4xl font-display font-bold text-loss-400 mb-2">
                   DEFEAT
                 </h1>
                 <p className="text-surface-400">Better luck next time!</p>
@@ -360,7 +360,7 @@ export default function FightResultsPage() {
             )
           ) : (
             <>
-              <h1 className="text-lg sm:text-4xl font-display font-bold text-white mb-2">
+              <h1 className="text-sm sm:text-4xl font-display font-bold text-white mb-2">
                 FIGHT RESULTS
               </h1>
               <p className="text-surface-400">
@@ -377,7 +377,7 @@ export default function FightResultsPage() {
             <div className={`flex-1 text-center ${winner?.userId === participantA?.userId ? 'opacity-100' : fight.winnerId ? 'opacity-60' : 'opacity-100'}`}>
               <div className="relative inline-block mb-2 sm:mb-3">
                 <div
-                  className={`w-14 h-14 sm:w-20 sm:h-20 rounded-full flex items-center justify-center text-xl sm:text-2xl font-bold ${
+                  className={`w-14 h-14 sm:w-20 sm:h-20 rounded-full flex items-center justify-center text-sm sm:text-2xl font-bold ${
                     winner?.userId === participantA?.userId
                       ? 'bg-gradient-to-br from-win-500 to-win-600 ring-4 ring-win-500/30'
                       : 'bg-surface-700'
@@ -395,7 +395,7 @@ export default function FightResultsPage() {
                 {participantA?.user?.handle || 'Unknown'}
               </h3>
               <p
-                className={`text-lg sm:text-2xl font-mono font-bold ${
+                className={`text-sm sm:text-2xl font-mono font-bold ${
                   parseDecimal(participantA?.finalPnlPercent) >= 0 ? 'text-win-400' : 'text-loss-400'
                 }`}
               >
@@ -425,14 +425,14 @@ export default function FightResultsPage() {
 
             {/* VS */}
             <div className="px-2 sm:px-6 flex-shrink-0">
-              <div className="text-xl sm:text-3xl font-display font-bold text-surface-600">VS</div>
+              <div className="text-sm sm:text-3xl font-display font-bold text-surface-600">VS</div>
             </div>
 
             {/* Participant B */}
             <div className={`flex-1 text-center ${winner?.userId === participantB?.userId ? 'opacity-100' : fight.winnerId ? 'opacity-60' : 'opacity-100'}`}>
               <div className="relative inline-block mb-2 sm:mb-3">
                 <div
-                  className={`w-14 h-14 sm:w-20 sm:h-20 rounded-full flex items-center justify-center text-xl sm:text-2xl font-bold ${
+                  className={`w-14 h-14 sm:w-20 sm:h-20 rounded-full flex items-center justify-center text-sm sm:text-2xl font-bold ${
                     winner?.userId === participantB?.userId
                       ? 'bg-gradient-to-br from-win-500 to-win-600 ring-4 ring-win-500/30'
                       : 'bg-surface-700'
@@ -452,7 +452,7 @@ export default function FightResultsPage() {
               {participantB && (
                 <>
                   <p
-                    className={`text-lg sm:text-2xl font-mono font-bold ${
+                    className={`text-sm sm:text-2xl font-mono font-bold ${
                       parseDecimal(participantB?.finalPnlPercent) >= 0 ? 'text-win-400' : 'text-loss-400'
                     }`}
                   >
@@ -488,25 +488,25 @@ export default function FightResultsPage() {
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-2">
           <div className="card p-4 text-center">
             <p className="text-surface-400 text-sm mb-1">Duration</p>
-            <p className="font-display font-bold text-lg text-white">
+            <p className="font-display font-bold text-sm sm:text-lg text-white">
               {formatDuration(fight.durationMinutes)}
             </p>
           </div>
           <div className="card p-4 text-center">
             <p className="text-surface-400 text-sm mb-1">Stake</p>
-            <p className="font-display font-bold text-lg text-white">
+            <p className="font-display font-bold text-sm sm:text-lg text-white">
               ${fight.stakeUsdc}
             </p>
           </div>
           <div className="card p-4 text-center">
             <p className="text-surface-400 text-sm mb-1">Started</p>
-            <p className="font-display font-bold text-lg text-white">
+            <p className="font-display font-bold text-sm sm:text-lg text-white">
               {fight.startedAt ? formatTime(fight.startedAt) : '-'}
             </p>
           </div>
           <div className="card p-4 text-center">
             <p className="text-surface-400 text-sm mb-1">Ended</p>
-            <p className="font-display font-bold text-lg text-white">
+            <p className="font-display font-bold text-sm sm:text-lg text-white">
               {fight.endedAt ? formatTime(fight.endedAt) : '-'}
             </p>
           </div>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -24,9 +24,7 @@
 
 html {
   font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
-}
-
-html {
+  overflow-x: hidden;
   overflow-y: scroll; /* Always show scrollbar to prevent layout shift */
 }
 

--- a/apps/web/src/app/lobby/page.tsx
+++ b/apps/web/src/app/lobby/page.tsx
@@ -268,7 +268,7 @@ export default function LobbyPage() {
           <div className="flex flex-col md:flex-row md:items-center justify-between gap-2 mb-2">
             {/* Title - Left */}
             <div>
-              <h2 className="font-display text-base sm:text-2xl font-bold text-white">Arena</h2>
+              <h2 className="font-display text-sm sm:text-2xl font-bold text-white">Arena</h2>
               <p className="text-surface-400 text-sm">Challenge traders to 1v1 battles. Win weekly prizes.</p>
             </div>
 
@@ -304,7 +304,7 @@ export default function LobbyPage() {
         {/* Compact Header with Stats */}
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-2 mb-2">
           <div>
-            <h2 className="font-display text-base sm:text-2xl font-bold text-white">Arena</h2>
+            <h2 className="font-display text-sm sm:text-2xl font-bold text-white">Arena</h2>
             <p className="text-surface-400 text-sm">
               Challenge traders to 1v1 battles. Win weekly prizes.
             </p>
@@ -463,7 +463,7 @@ export default function LobbyPage() {
           </div>
         ) : displayFights.length === 0 ? (
           <div className="text-center py-16 min-h-[200px] flex flex-col items-center justify-center">
-            <p className="text-surface-400 text-lg mb-4">
+            <p className="text-surface-400 text-sm sm:text-lg mb-4">
               {hasActiveFilters ? (
                 'No fights match your filters'
               ) : (
@@ -586,7 +586,7 @@ export default function LobbyPage() {
           <div className="modal-content p-6 max-w-md" onClick={(e) => e.stopPropagation()}>
             {/* Modal Header */}
             <div className="flex items-center justify-between mb-2">
-              <h3 className="font-display text-xl font-bold uppercase tracking-wide">
+              <h3 className="font-display text-sm sm:text-xl font-bold uppercase tracking-wide">
                 Create Fight
               </h3>
               <button

--- a/apps/web/src/app/profile/[id]/page.tsx
+++ b/apps/web/src/app/profile/[id]/page.tsx
@@ -216,7 +216,7 @@ export default function ProfilePage() {
               <div className="w-20 h-20 mx-auto mb-2 rounded-full bg-surface-800 flex items-center justify-center">
                 <span className="text-4xl opacity-50">?</span>
               </div>
-              <p className="text-xl mb-4 text-surface-400">{error || 'Fighter not found'}</p>
+              <p className="text-sm sm:text-xl mb-4 text-surface-400">{error || 'Fighter not found'}</p>
               <Link href="/lobby" className="btn-primary">
                 Back to Arena
               </Link>
@@ -245,7 +245,7 @@ export default function ProfilePage() {
             {/* Avatar */}
             <div className="relative">
               <div className="p-1 rounded-full bg-gradient-to-r from-primary-500 to-accent-500">
-                <div className="avatar w-20 h-20 text-2xl bg-surface-850">
+                <div className="avatar w-20 h-20 text-sm sm:text-2xl bg-surface-850">
                   {profile.handle[0]?.toUpperCase() || '?'}
                 </div>
               </div>
@@ -423,7 +423,7 @@ export default function ProfilePage() {
         {/* Performance Chart */}
         <div className="card overflow-hidden mb-2">
           <div className="p-4 sm:p-6 border-b border-surface-800">
-            <h2 className="text-lg sm:text-xl font-bold">Performance History</h2>
+            <h2 className="text-sm sm:text-xl font-bold">Performance History</h2>
           </div>
           <div className="p-4">
             {mode === 'fights' ? (
@@ -439,7 +439,7 @@ export default function ProfilePage() {
           /* Fight History */
           <div className="card overflow-hidden">
             <div className="p-4 sm:p-6 border-b border-surface-800">
-              <h2 className="text-lg sm:text-xl font-bold">Fight History</h2>
+              <h2 className="text-sm sm:text-xl font-bold">Fight History</h2>
             </div>
             {fights.length === 0 ? (
               <div className="p-12 text-center">

--- a/apps/web/src/app/referrals/page.tsx
+++ b/apps/web/src/app/referrals/page.tsx
@@ -131,7 +131,7 @@ export default function ReferralsPage() {
           <div className="container mx-auto px-2 md:px-6 py-8">
             <div className="card p-12 text-center">
               <GroupsIcon sx={{ fontSize: 64, color: '#52525b', marginBottom: 16 }} />
-              <h3 className="text-lg font-semibold text-surface-300 mb-2">Connect your wallet</h3>
+              <h3 className="text-sm sm:text-lg font-semibold text-surface-300 mb-2">Connect your wallet</h3>
               <p className="text-surface-500">Please connect your wallet to access the referral system.</p>
             </div>
           </div>
@@ -246,7 +246,7 @@ export default function ReferralsPage() {
           <div className="container mx-auto px-2 md:px-6 py-8">
             <div className="card p-12 text-center">
               <GroupsIcon sx={{ fontSize: 64, color: '#52525b', marginBottom: 16 }} />
-              <h3 className="text-lg font-semibold text-surface-300 mb-2">Referral system unavailable</h3>
+              <h3 className="text-sm sm:text-lg font-semibold text-surface-300 mb-2">Referral system unavailable</h3>
               <p className="text-surface-500">Please try again later.</p>
             </div>
           </div>
@@ -263,7 +263,7 @@ export default function ReferralsPage() {
           <div className="flex items-center gap-3 mb-2">
             <GroupsIcon sx={{ color: '#f97316', fontSize: 28 }} />
             <div>
-              <h1 className="font-display text-xl sm:text-2xl font-bold text-white">Referral Program</h1>
+              <h1 className="font-display text-sm sm:text-2xl font-bold text-white">Referral Program</h1>
               <p className="text-surface-400 text-xs sm:text-sm">Earn {dashboard.commissionRates.t1}% commission on referrals</p>
             </div>
           </div>
@@ -306,7 +306,7 @@ export default function ReferralsPage() {
                 Unclaimed Earnings
               </h2>
               <div className="mb-4">
-                <p className="text-lg sm:text-4xl font-bold text-white mb-1">
+                <p className="text-sm sm:text-4xl font-bold text-white mb-1">
                   ${dashboard.unclaimedPayout.toFixed(2)}
                 </p>
                 <p className="text-xs text-surface-500">Minimum ${minPayoutAmount.toFixed(2)} to claim</p>
@@ -335,7 +335,7 @@ export default function ReferralsPage() {
                 </div>
                 <h3 className="text-sm font-semibold text-surface-300">Total Referrals</h3>
               </div>
-              <p className="text-base sm:text-3xl font-bold text-white mb-2">{dashboard.totalReferrals.total}</p>
+              <p className="text-sm sm:text-3xl font-bold text-white mb-2">{dashboard.totalReferrals.total}</p>
               <div className="flex gap-3 text-xs text-surface-400">
                 <span>T1: {dashboard.totalReferrals.t1}</span>
                 <span>T2: {dashboard.totalReferrals.t2}</span>
@@ -351,7 +351,7 @@ export default function ReferralsPage() {
                 </div>
                 <h3 className="text-sm font-semibold text-surface-300">Total Earnings</h3>
               </div>
-              <p className="text-base sm:text-3xl font-bold text-white mb-2">${dashboard.totalEarnings.total.toFixed(2)}</p>
+              <p className="text-sm sm:text-3xl font-bold text-white mb-2">${dashboard.totalEarnings.total.toFixed(2)}</p>
               <div className="flex gap-3 text-xs text-surface-400">
                 <span>T1: ${dashboard.totalEarnings.t1.toFixed(2)}</span>
                 <span>T2: ${dashboard.totalEarnings.t2.toFixed(2)}</span>
@@ -367,7 +367,7 @@ export default function ReferralsPage() {
                 </div>
                 <h3 className="text-sm font-semibold text-surface-300">Referral Volume</h3>
               </div>
-              <p className="text-base sm:text-3xl font-bold text-white mb-2">${dashboard.referralVolume.total.toFixed(2)}</p>
+              <p className="text-sm sm:text-3xl font-bold text-white mb-2">${dashboard.referralVolume.total.toFixed(2)}</p>
               <div className="flex gap-3 text-xs text-surface-400">
                 <span>T1: ${dashboard.referralVolume.t1.toFixed(2)}</span>
                 <span>T2: ${dashboard.referralVolume.t2.toFixed(2)}</span>

--- a/apps/web/src/app/rewards/page.tsx
+++ b/apps/web/src/app/rewards/page.tsx
@@ -81,13 +81,13 @@ function PrizeRow({
       </td>
 
       {/* Period */}
-      <td className="py-4 px-4 text-surface-400 text-sm">
+      <td className="py-4 px-4 text-surface-400 text-xs whitespace-nowrap">
         {weekLabel}
       </td>
 
       {/* Amount */}
       <td className="py-4 px-4 text-right">
-        <span className="text-lg font-bold text-white">${prize.amount.toFixed(2)}</span>
+        <span className="text-sm font-bold text-white">${prize.amount.toFixed(2)}</span>
       </td>
 
       {/* Status */}
@@ -249,7 +249,7 @@ export default function RewardsPage() {
           <div className="container mx-auto px-2 2xl:px-6 py-8">
             <div className="card p-12 border-x-0 22xl:border-x border-y 2xl:border border-surface-800 text-center mx-0 2xl:mx-0">
               <EmojiEventsIcon sx={{ fontSize: 64, color: '#52525b', marginBottom: 16 }} />
-              <h3 className="text-lg font-semibold text-surface-300 mb-2">Connect your wallet</h3>
+              <h3 className="text-sm sm:text-lg font-semibold text-surface-300 mb-2">Connect your wallet</h3>
               <p className="text-surface-500">Please connect your wallet to view your rewards.</p>
             </div>
           </div>
@@ -266,7 +266,7 @@ export default function RewardsPage() {
           <div className="flex items-center gap-2 sm:gap-3 mb-2 px-2 2xl:px-0">
             <EmojiEventsIcon sx={{ color: '#f97316', fontSize: 28 }} />
             <div>
-              <h1 className="font-display text-xl sm:text-2xl font-bold text-white">Rewards</h1>
+              <h1 className="font-display text-sm sm:text-2xl font-bold text-white">Rewards</h1>
               <p className="text-surface-400 text-xs sm:text-sm">Claim your weekly prizes</p>
             </div>
           </div>
@@ -310,7 +310,7 @@ export default function RewardsPage() {
                     </div>
 
                     {/* Prize amount (large, centered where "2nd" was) */}
-                    <div className="text-3xl font-bold text-primary-400">
+                    <div className="text-sm sm:text-3xl font-bold text-primary-400">
                       ${currentStanding.estimatedPrize.toFixed(2)}
                     </div>
                     <p className="text-xs text-surface-500 mt-1">Estimated Prize</p>
@@ -331,7 +331,7 @@ export default function RewardsPage() {
                   </div>
                   <h3 className="text-sm font-semibold text-surface-300">Total Prizes</h3>
                 </div>
-                <p className="text-base sm:text-3xl font-bold text-white">{prizes.length}</p>
+                <p className="text-sm sm:text-3xl font-bold text-white">{prizes.length}</p>
               </div>
 
               {/* Total Earned */}
@@ -342,7 +342,7 @@ export default function RewardsPage() {
                   </div>
                   <h3 className="text-sm font-semibold text-surface-300">Total Earned</h3>
                 </div>
-                <p className="text-base sm:text-3xl font-bold text-white">
+                <p className="text-sm sm:text-3xl font-bold text-white">
                   ${prizes.reduce((sum, p) => sum + p.amount, 0).toFixed(2)}
                 </p>
               </div>
@@ -355,7 +355,7 @@ export default function RewardsPage() {
                   </div>
                   <h3 className="text-sm font-semibold text-surface-300">Total Claimed</h3>
                 </div>
-                <p className="text-base sm:text-3xl font-bold text-white">${totalClaimed.toFixed(2)}</p>
+                <p className="text-sm sm:text-3xl font-bold text-white">${totalClaimed.toFixed(2)}</p>
               </div>
             </div>
           )}
@@ -416,7 +416,7 @@ export default function RewardsPage() {
           {!isLoading && !error && prizes.length === 0 && (
             <div className="card p-12 border-x-0 22xl:border-x border-y 2xl:border border-surface-800 text-center mx-0 2xl:mx-0">
               <EmojiEventsIcon sx={{ color: '#52525b', fontSize: 64, marginBottom: 16 }} />
-              <h3 className="text-lg font-semibold text-surface-300 mb-2">No prizes yet</h3>
+              <h3 className="text-sm sm:text-lg font-semibold text-surface-300 mb-2">No prizes yet</h3>
               <p className="text-surface-500 mb-2">
                 Win fights to earn weekly prizes! Top 3 traders each week share the prize pool.
               </p>

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -290,8 +290,8 @@ export function AppShell({ children }: AppShellProps) {
       >
         {/* Header */}
         <header className="border-surface-800 bg-surface-850 sticky top-0 z-50">
-          <div className="w-full px-4">
-            <div className="flex items-center justify-between h-16">
+          <div className="w-full px-4 overflow-hidden">
+            <div className="flex items-center justify-between h-16 min-w-0">
               {/* Logo - always visible, hidden on desktop when sidebar is showing */}
               <div className={`flex-shrink-0 ${sidebarState !== 'hidden' ? 'max-[1199px]:block hidden' : ''}`}>
                 <Link href="/trade">
@@ -313,9 +313,9 @@ export function AppShell({ children }: AppShellProps) {
                 {/* Position Dropdown Icon */}
                 {isAuthenticated && settings.showQuickBar && <QuickPositionsDropdown />}
 
-                {/* Balance Display with Dropdown */}
+                {/* Balance Display with Dropdown - hidden on mobile (balance shows in bottom bar) */}
                 {settings.showWallet && (
-                  <div className="relative" ref={desktopDropdownRef}>
+                  <div className="relative hidden min-[1200px]:block" ref={desktopDropdownRef}>
                     <button
                       onClick={() => setShowWalletDropdown(!showWalletDropdown)}
                       className="flex items-center gap-1.5 px-2 py-1.5 bg-surface-800 hover:bg-surface-700 rounded text-sm transition-colors cursor-pointer"
@@ -351,8 +351,8 @@ export function AppShell({ children }: AppShellProps) {
                 {/* Notifications Bell */}
                 {settings.showNotifications && <NotificationBell />}
 
-                {/* Wallet Connect Button - hidden on mobile (shows in footer) */}
-                <div className="wallet-compact hidden sm:block">
+                {/* Wallet Connect Button - visible on all screen sizes */}
+                <div className="wallet-compact min-w-0 overflow-hidden">
                   <WalletButton />
                 </div>
               </div>


### PR DESCRIPTION
…e layout

- Cap all mobile headers to text-sm (14px) across rewards, referrals, fight, profile, and lobby pages
- Fix horizontal scroll on all pages by adding overflow-x:hidden to html and overflow constraints on header flex containers
- Show wallet connect button on mobile navbar (was incorrectly hidden)
- Hide balance display below 1200px to match bottom bar breakpoint
- Fix Prize History table: reduce Amount size, add whitespace-nowrap to Period