### PR TITLE
fix: retry Pacifica account auto-link when initial detection fails

### DIFF
--- a/apps/web/src/app/api/auth/pacifica/me/route.ts
+++ b/apps/web/src/app/api/auth/pacifica/me/route.ts
@@ -1,17 +1,47 @@
 /**
  * Get current user's Pacifica connection status
  * GET /api/auth/pacifica/me
+ *
+ * If no connection exists in the database, retries auto-linking
+ * by checking the Pacifica API with the user's wallet address.
+ * This handles cases where the initial auto-link during login failed
+ * (e.g., Pacifica API was temporarily down or rate limited).
  */
 import { withAuth } from '@/lib/server/auth';
 import * as AuthService from '@/lib/server/services/auth';
 import { errorResponse } from '@/lib/server/errors';
 
+// Rate limit auto-link retries: max once per 30 seconds per user
+const lastRetryAttempt = new Map<string, number>();
+const RETRY_INTERVAL_MS = 30_000;
+
 export async function GET(request: Request) {
   try {
     return await withAuth(request, async (user) => {
-      const connection = await AuthService.getConnection(user.userId);
+      let connection = await AuthService.getConnection(user.userId);
 
-      if (!connection) {
+      // If no connection, try to auto-link by checking the Pacifica API
+      // Rate limited to avoid hammering Pacifica on every poll
+      if (!connection || !connection.isActive) {
+        const lastAttempt = lastRetryAttempt.get(user.userId) || 0;
+        const now = Date.now();
+
+        if (now - lastAttempt > RETRY_INTERVAL_MS) {
+          lastRetryAttempt.set(user.userId, now);
+          try {
+            const result = await AuthService.linkPacificaAccount(user.userId, user.walletAddress);
+            if (result.connected) {
+              connection = await AuthService.getConnection(user.userId);
+              // Clear from retry map on success
+              lastRetryAttempt.delete(user.userId);
+            }
+          } catch {
+            // Pacifica account doesn't exist yet or API error - that's OK
+          }
+        }
+      }
+
+      if (!connection || !connection.isActive) {
         return {
           connected: false,
           pacificaAddress: null,


### PR DESCRIPTION
The polling endpoint /api/auth/pacifica/me only checked the database, so if the initial auto-link during wallet connect failed (API timeout, rate limit, etc.), the user was stuck as unconnected forever. Now retries linkPacificaAccount on each poll when no active connection exists, rate-limited to once per 30s per user.