### PR TITLE
feat: stop orders, reduce only toggle, and trading UX improvements

### DIFF
--- a/apps/web/src/app/api/orders/stop/create/route.ts
+++ b/apps/web/src/app/api/orders/stop/create/route.ts
@@ -86,7 +86,9 @@ export async function POST(request: Request) {
       walletAddress: account,
       actionType: 'CREATE_STOP',
       symbol,
-      side: side === 'ask' ? 'LONG' : 'SHORT', // Position side being closed
+      side: reduce_only
+        ? (side === 'ask' ? 'LONG' : 'SHORT')   // closing: ask closes LONG, bid closes SHORT
+        : (side === 'bid' ? 'LONG' : 'SHORT'),  // opening: bid=LONG, ask=SHORT
       price: stop_order.stop_price,
       size: stop_order.amount,
       reduceOnly: reduce_only,

--- a/apps/web/src/components/QuickPositionModal.tsx
+++ b/apps/web/src/components/QuickPositionModal.tsx
@@ -447,17 +447,6 @@ export function QuickPositionModal({ position, isOpen, onClose }: QuickPositionM
 
           {activeTab === 'limit' && (
             <div className="space-y-4">
-              {/* Live Price Display */}
-              <div className="flex items-center justify-between bg-surface-900/50 rounded-lg px-3 py-2">
-                <div className="flex items-center gap-2">
-                  <span className="text-white font-mono text-lg tabular-nums">{formatPrice(currentPrice)}</span>
-                  <span className="text-surface-500 text-sm">USD</span>
-                </div>
-                <span className="text-[10px] text-win-400 bg-win-500/20 px-1.5 py-0.5 rounded font-medium animate-pulse">
-                  LIVE
-                </span>
-              </div>
-
               {/* Price Input */}
               <div>
                 <label className="block text-xs text-surface-400 mb-2">Price</label>

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -9,7 +9,7 @@ export { useOrderBook } from './useOrderBook';
 export type { AggLevel } from './useOrderBook';
 export { useCandles } from './useCandles';
 export type { CandleData } from './useCandles';
-export { useCreateMarketOrder, useCreateLimitOrder, useCancelOrder, useCancelStopOrder, useCancelAllOrders, useSetPositionTpSl, useCreateStopOrder, useSetLeverage, useWithdraw, useEditOrder } from './useOrders';
+export { useCreateMarketOrder, useCreateLimitOrder, useCancelOrder, useCancelStopOrder, useCancelAllOrders, useSetPositionTpSl, useCreateStopOrder, useCreateStandaloneStopOrder, useSetLeverage, useWithdraw, useEditOrder } from './useOrders';
 export { usePositions, useAccountInfo, useAccountSettings, useOpenOrders, useMarkets, useMarket, useTradeHistory, useOrderHistory } from './usePositions';
 export { usePacificaConnection } from './usePacificaConnection';
 export { useBuilderCodeStatus, useApproveBuilderCode, getBuilderCode } from './useBuilderCode';

--- a/apps/web/src/hooks/useAccount.ts
+++ b/apps/web/src/hooks/useAccount.ts
@@ -173,7 +173,7 @@ export function useAccount(): UseAccountReturn {
         side: order.side === 'bid' ? 'LONG' : 'SHORT',
         type: typeDisplay,
         size: resolvedSize,
-        price: order.stop_price || order.price || '0', // Use stop_price for TP/SL orders
+        price: isTpSlOrder ? (order.stop_price || order.price || '0') : (order.price || '0'), // TP/SL: use stop_price as display price; stop-limit: keep limit price
         filled: order.filled_amount || '0',
         status: order.reduce_only ? 'REDUCE_ONLY' : 'OPEN',
         reduceOnly: order.reduce_only || false,

--- a/apps/web/src/lib/server/exchanges/adapter.ts
+++ b/apps/web/src/lib/server/exchanges/adapter.ts
@@ -176,6 +176,16 @@ export interface LimitOrderParams {
   clientOrderId?: string;
 }
 
+export interface StopOrderParams {
+  symbol: string;
+  side: OrderSide;
+  amount: string;
+  stopPrice: string;         // Trigger price
+  limitPrice?: string;       // Makes it stop-limit if provided
+  reduceOnly?: boolean;
+  clientOrderId?: string;
+}
+
 export interface CancelOrderParams {
   symbol: string;
   orderId?: string | number;
@@ -238,6 +248,7 @@ export interface ExchangeAdapter {
 
   createMarketOrder(auth: AuthContext, params: MarketOrderParams): Promise<{ orderId: string | number }>;
   createLimitOrder(auth: AuthContext, params: LimitOrderParams): Promise<{ orderId: string | number }>;
+  createStopOrder(auth: AuthContext, params: StopOrderParams): Promise<{ orderId: string | number }>;
   cancelOrder(auth: AuthContext, params: CancelOrderParams): Promise<{ success: boolean }>;
   cancelAllOrders(auth: AuthContext, params: CancelAllOrdersParams): Promise<{ cancelledCount: number }>;
   updateLeverage(auth: AuthContext, symbol: string, leverage: number): Promise<{ success: boolean }>;

--- a/apps/web/src/lib/server/exchanges/cached-adapter.ts
+++ b/apps/web/src/lib/server/exchanges/cached-adapter.ts
@@ -19,6 +19,7 @@ import {
   AccountSetting,
   MarketOrderParams,
   LimitOrderParams,
+  StopOrderParams,
   CancelOrderParams,
   CancelAllOrdersParams,
   KlineParams,
@@ -172,6 +173,12 @@ export class CachedExchangeAdapter implements ExchangeAdapter {
 
   async createLimitOrder(auth: AuthContext, params: LimitOrderParams): Promise<{ orderId: string | number }> {
     const result = await this.adapter.createLimitOrder(auth, params);
+    await this.invalidateAccountCache(auth.accountId);
+    return result;
+  }
+
+  async createStopOrder(auth: AuthContext, params: StopOrderParams): Promise<{ orderId: string | number }> {
+    const result = await this.adapter.createStopOrder(auth, params);
     await this.invalidateAccountCache(auth.accountId);
     return result;
   }

--- a/apps/web/src/lib/server/exchanges/pacifica-adapter.ts
+++ b/apps/web/src/lib/server/exchanges/pacifica-adapter.ts
@@ -24,6 +24,7 @@ import {
   AccountSetting,
   MarketOrderParams,
   LimitOrderParams,
+  StopOrderParams,
   CancelOrderParams,
   CancelAllOrdersParams,
   KlineParams,
@@ -300,6 +301,26 @@ export class PacificaAdapter implements ExchangeAdapter {
       amount: params.amount,
       side: params.side === 'BUY' ? 'bid' : 'ask',
       tif: this.denormalizeTimeInForce(params.timeInForce || 'GTC'),
+      reduceOnly: params.reduceOnly || false,
+      clientOrderId: params.clientOrderId,
+    });
+
+    return { orderId: result.order_id };
+  }
+
+  async createStopOrder(
+    auth: AuthContext,
+    params: StopOrderParams
+  ): Promise<{ orderId: string | number }> {
+    const keypair = this.extractKeypair(auth);
+    const pacificaSymbol = this.denormalizeSymbol(params.symbol);
+
+    const result = await Pacifica.createStopOrder(keypair, {
+      symbol: pacificaSymbol,
+      side: params.side === 'BUY' ? 'bid' : 'ask',
+      amount: params.amount,
+      stopPrice: params.stopPrice,
+      limitPrice: params.limitPrice,
       reduceOnly: params.reduceOnly || false,
       clientOrderId: params.clientOrderId,
     });

--- a/apps/web/src/lib/server/pacifica-signing.ts
+++ b/apps/web/src/lib/server/pacifica-signing.ts
@@ -243,6 +243,42 @@ export function signCancelAllOrders(
 }
 
 /**
+ * Sign a stop order request
+ */
+export function signStopOrder(
+  keypair: nacl.SignKeyPair,
+  params: {
+    symbol: string;
+    side: 'bid' | 'ask';
+    reduceOnly: boolean;
+    stopPrice: string;
+    amount: string;
+    limitPrice?: string;
+    clientOrderId?: string;
+  }
+): Record<string, unknown> {
+  const stopOrder: Record<string, unknown> = {
+    stop_price: params.stopPrice,
+    amount: params.amount,
+  };
+
+  if (params.limitPrice) {
+    stopOrder.limit_price = params.limitPrice;
+  }
+
+  if (params.clientOrderId) {
+    stopOrder.client_order_id = params.clientOrderId;
+  }
+
+  return signRequest(keypair, 'create_stop_order', {
+    symbol: params.symbol,
+    side: params.side,
+    reduce_only: params.reduceOnly,
+    stop_order: stopOrder,
+  });
+}
+
+/**
  * Sign an update leverage request
  */
 export function signUpdateLeverage(

--- a/apps/web/src/lib/server/pacifica.ts
+++ b/apps/web/src/lib/server/pacifica.ts
@@ -234,6 +234,27 @@ export async function createLimitOrder(
 }
 
 /**
+ * Create a stop order
+ * POST /api/v1/orders/stop/create
+ */
+export async function createStopOrder(
+  keypair: nacl.SignKeyPair,
+  params: {
+    symbol: string;
+    side: 'bid' | 'ask';
+    amount: string;
+    stopPrice: string;
+    limitPrice?: string;
+    reduceOnly: boolean;
+    clientOrderId?: string;
+  }
+): Promise<{ order_id: number }> {
+  const signedPayload = PacificaSigning.signStopOrder(keypair, params);
+
+  return request<{ order_id: number }>('POST', '/api/v1/orders/stop/create', signedPayload);
+}
+
+/**
  * Cancel an order
  * POST /api/v1/orders/cancel
  */


### PR DESCRIPTION
- Implement stop-market and stop-limit order types (full stack)
- Add StopOrderParams to exchange adapter interface
- Add createStopOrder to pacifica-adapter and cached-adapter
- Add useCreateStandaloneStopOrder hook for order form
- Add reduce only toggle for all 4 order types
- Show closeable position size when reduce only is active
- Fix stop order cancellation (route to cancel_stop_order endpoint)
- Fix price column display for stop orders in open orders table
- Add Mid button to auto-fill current price on price inputs
- Add $11 minimum order size validation
- Fix slider drag with touch-none and step rounding
- Remove redundant LIVE price display from QuickPositionModal