### PR TITLE
feat: mandatory wallet selector modal on mobile + simplify wallet config

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -274,6 +274,19 @@ body {
   line-height: 1.5 !important;
 }
 
+/* Truncate wallet address only in the navbar, not in modals */
+.wallet-compact .wallet-adapter-button {
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+  max-width: 160px !important;
+}
+
+/* Wallet dropdown menu needs high z-index to appear above header */
+.wallet-adapter-dropdown-list {
+  z-index: 9999 !important;
+}
+
 .wallet-adapter-button:hover {
   background-color: #1c1c1f !important;
   border-color: #212124 !important;

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -290,7 +290,7 @@ export function AppShell({ children }: AppShellProps) {
       >
         {/* Header */}
         <header className="border-surface-800 bg-surface-850 sticky top-0 z-50">
-          <div className="w-full px-4 overflow-hidden">
+          <div className="w-full px-4">
             <div className="flex items-center justify-between h-16 min-w-0">
               {/* Logo - always visible, hidden on desktop when sidebar is showing */}
               <div className={`flex-shrink-0 ${sidebarState !== 'hidden' ? 'max-[1199px]:block hidden' : ''}`}>
@@ -352,7 +352,7 @@ export function AppShell({ children }: AppShellProps) {
                 {settings.showNotifications && <NotificationBell />}
 
                 {/* Wallet Connect Button - visible on all screen sizes */}
-                <div className="wallet-compact min-w-0 overflow-hidden">
+                <div className="wallet-compact min-w-0 relative z-50">
                   <WalletButton />
                 </div>
               </div>

--- a/apps/web/src/components/MobilePhantomRedirect.tsx
+++ b/apps/web/src/components/MobilePhantomRedirect.tsx
@@ -1,23 +1,73 @@
 'use client';
 
-import { useEffect } from 'react';
-import { isMobileDevice, isPhantomBrowser, getPhantomDeepLink } from '@/lib/mobile';
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
+import { isMobileDevice, isInWalletBrowser, MOBILE_WALLETS, type MobileWallet } from '@/lib/mobile';
 
 /**
- * Auto-redirects mobile users to Phantom's dApp browser.
- * On mobile (outside Phantom), wallet connection doesn't work properly,
- * so we force-redirect to open TFC inside Phantom's in-app browser.
+ * On mobile (outside any wallet dApp browser), shows a mandatory modal
+ * forcing the user to open TFC inside a wallet app.
+ * The modal cannot be dismissed — the only way forward is to pick a wallet.
  */
 export function MobilePhantomRedirect() {
+  const [showModal, setShowModal] = useState(false);
+
   useEffect(() => {
     if (typeof window === 'undefined') return;
-
-    // Only redirect on mobile devices NOT already in Phantom's browser
-    if (isMobileDevice() && !isPhantomBrowser()) {
-      const currentUrl = window.location.href;
-      window.location.href = getPhantomDeepLink(currentUrl);
+    if (isMobileDevice() && !isInWalletBrowser()) {
+      setShowModal(true);
     }
   }, []);
 
-  return null;
+  if (!showModal) return null;
+
+  const handleSelectWallet = (wallet: MobileWallet) => {
+    const currentUrl = window.location.href;
+    window.location.href = wallet.getDeepLink(currentUrl);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-end sm:items-center justify-center p-0 sm:p-4">
+      {/* Backdrop — no onClick, cannot dismiss */}
+      <div className="absolute inset-0 bg-black/90 backdrop-blur-sm" />
+
+      {/* Modal */}
+      <div className="relative bg-surface-900 border-t border-surface-700 sm:border sm:rounded-2xl rounded-t-2xl p-6 w-full sm:max-w-sm shadow-2xl">
+        <h2 className="text-lg font-bold text-white text-center mb-1">
+          Open in Wallet App
+        </h2>
+        <p className="text-surface-400 text-xs text-center mb-5">
+          TFC requires a wallet app to trade. Pick your wallet to continue.
+        </p>
+
+        {/* Wallet list */}
+        <div className="space-y-2">
+          {MOBILE_WALLETS.map((wallet) => (
+            <button
+              key={wallet.id}
+              onClick={() => handleSelectWallet(wallet)}
+              className="w-full flex items-center gap-3 px-4 py-3 bg-surface-800 hover:bg-surface-700 rounded-xl transition-colors"
+            >
+              <Image
+                src={wallet.icon}
+                alt={wallet.name}
+                width={32}
+                height={32}
+                className="rounded-lg"
+              />
+              <span className="text-white font-medium text-sm">{wallet.name}</span>
+              <svg className="w-4 h-4 text-surface-400 ml-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          ))}
+        </div>
+
+        {/* No cancel button — mandatory */}
+        <p className="text-surface-500 text-[10px] text-center mt-4">
+          Don't have a wallet? Download <a href="https://phantom.app/download" className="text-orange-400 underline" target="_blank" rel="noopener noreferrer">Phantom</a> or <a href="https://solflare.com/download" className="text-orange-400 underline" target="_blank" rel="noopener noreferrer">Solflare</a>.
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/components/MobileWalletRedirect.tsx
+++ b/apps/web/src/components/MobileWalletRedirect.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { MOBILE_WALLETS, type MobileWallet } from '@/lib/mobile';
+
+/**
+ * Mobile wallet selector modal.
+ * Shows a list of supported wallets — tapping one opens TFC inside that wallet's dApp browser.
+ */
+export function MobileWalletSelector({ onClose }: { onClose: () => void }) {
+  const handleSelectWallet = (wallet: MobileWallet) => {
+    const currentUrl = window.location.href;
+    window.location.href = wallet.getDeepLink(currentUrl);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-end sm:items-center justify-center p-0 sm:p-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/80 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal - bottom sheet on mobile */}
+      <div className="relative bg-surface-900 border border-surface-700 rounded-t-2xl sm:rounded-2xl p-5 w-full sm:max-w-sm shadow-2xl">
+        <h2 className="text-lg font-display font-bold text-white text-center mb-1">
+          Connect Wallet
+        </h2>
+        <p className="text-surface-400 text-xs text-center mb-4">
+          Open TFC inside your wallet app
+        </p>
+
+        {/* Wallet list */}
+        <div className="space-y-2">
+          {MOBILE_WALLETS.map((wallet) => (
+            <button
+              key={wallet.id}
+              onClick={() => handleSelectWallet(wallet)}
+              className="w-full flex items-center gap-3 px-4 py-3 bg-surface-800 hover:bg-surface-700 rounded-xl transition-colors"
+            >
+              <Image
+                src={wallet.icon}
+                alt={wallet.name}
+                width={32}
+                height={32}
+                className="rounded-lg"
+              />
+              <span className="text-white font-medium text-sm">{wallet.name}</span>
+              <svg className="w-4 h-4 text-surface-400 ml-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          ))}
+        </div>
+
+        {/* Cancel */}
+        <button
+          onClick={onClose}
+          className="w-full mt-3 py-2.5 text-surface-400 hover:text-surface-200 text-sm transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/WalletButton.tsx
+++ b/apps/web/src/components/WalletButton.tsx
@@ -10,6 +10,10 @@ import { useAuth } from '@/hooks';
  * - "Signing..." while signature is being requested
  * - "Authenticating..." while backend auth is in progress
  * - Wallet address when fully connected and authenticated
+ *
+ * Mobile users outside a wallet dApp browser are handled by
+ * MobilePhantomRedirect (mandatory modal), so no mobile-specific
+ * logic is needed here.
  */
 export function WalletButton() {
   const { connected, connecting } = useWallet();

--- a/apps/web/src/components/WalletProvider.tsx
+++ b/apps/web/src/components/WalletProvider.tsx
@@ -4,12 +4,6 @@ import { ReactNode, useMemo, useEffect, useState } from 'react';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
 import { PhantomWalletAdapter, SolflareWalletAdapter } from '@solana/wallet-adapter-wallets';
-import {
-  SolanaMobileWalletAdapter,
-  createDefaultAddressSelector,
-  createDefaultAuthorizationResultCache,
-  createDefaultWalletNotFoundHandler,
-} from '@solana-mobile/wallet-adapter-mobile';
 import { PacificaConnectionSync } from './PacificaConnectionSync';
 import { PacificaWebSocketInit } from './PacificaWebSocketInit';
 import { getDeviceContext, type DeviceContext } from '@/lib/mobile';
@@ -86,37 +80,9 @@ export function WalletProviderWrapper({ children }: { children: ReactNode }) {
 
   // Configure wallets based on device context
   const wallets = useMemo(() => {
-    if (deviceContext === 'phantom-browser') {
-      // Inside Phantom's dApp browser: provider is pre-injected
-      // Only use PhantomWalletAdapter for seamless connection
-      return [new PhantomWalletAdapter()];
-    }
-
-    if (deviceContext === 'ios-mobile-browser') {
-      // iOS Safari/Chrome: PhantomWalletAdapter handles redirect to Phantom's in-app browser
-      // SolanaMobileWalletAdapter does NOT work on iOS (requires Android MWA protocol)
-      return [new PhantomWalletAdapter()];
-    }
-
-    if (deviceContext === 'android-mobile-browser') {
-      // Android mobile browser: use Mobile Wallet Adapter for deep linking
-      const cluster = (process.env.NEXT_PUBLIC_SOLANA_NETWORK as 'devnet' | 'mainnet-beta') || 'devnet';
-      return [
-        new SolanaMobileWalletAdapter({
-          addressSelector: createDefaultAddressSelector(),
-          appIdentity: {
-            name: 'Trading Fight Club',
-            uri: typeof window !== 'undefined' ? window.location.origin : 'https://tradefight.club',
-            icon: '/images/logos/favicon-white-192.png',
-          },
-          authorizationResultCache: createDefaultAuthorizationResultCache(),
-          cluster,
-          onWalletNotFound: createDefaultWalletNotFoundHandler(),
-        }),
-      ];
-    }
-
-    // Desktop: use browser extensions
+    // Inside any wallet dApp browser OR on mobile: offer both adapters
+    // so the wallet modal shows the available provider(s).
+    // On desktop: browser extensions handle detection automatically.
     return [
       new PhantomWalletAdapter(),
       new SolflareWalletAdapter(),

--- a/apps/web/src/lib/mobile.ts
+++ b/apps/web/src/lib/mobile.ts
@@ -1,5 +1,5 @@
 /**
- * Mobile detection utilities for Phantom dApp browser integration
+ * Mobile detection utilities and wallet deep link support
  */
 
 /**
@@ -41,6 +41,22 @@ export function isPhantomBrowser(): boolean {
 }
 
 /**
+ * Check if we're running inside any supported wallet's dApp browser
+ */
+export function isInWalletBrowser(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  // Phantom
+  if (isPhantomBrowser()) return true;
+
+  // Solflare injects window.solflare
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((window as any).solflare?.isSolflare) return true;
+
+  return false;
+}
+
+/**
  * Get the device context for wallet configuration
  * - desktop: browser extensions (Phantom, Solflare)
  * - phantom-browser: inside Phantom's dApp browser (provider injected)
@@ -66,6 +82,41 @@ export function getDeviceContext(): DeviceContext {
 
   return 'android-mobile-browser';
 }
+
+/**
+ * Supported mobile wallets with their deep link schemes
+ */
+export interface MobileWallet {
+  id: string;
+  name: string;
+  icon: string;         // Path to icon in /public/wallets/
+  getDeepLink: (appUrl: string) => string;
+  downloadUrl: string;
+}
+
+export const MOBILE_WALLETS: MobileWallet[] = [
+  {
+    id: 'phantom',
+    name: 'Phantom',
+    icon: '/wallets/phantom.svg',
+    getDeepLink: (appUrl: string) => {
+      const encodedUrl = encodeURIComponent(appUrl);
+      return `phantom://browse/${encodedUrl}`;
+    },
+    downloadUrl: 'https://phantom.app/download',
+  },
+  {
+    id: 'solflare',
+    name: 'Solflare',
+    icon: '/wallets/solflare.svg',
+    getDeepLink: (appUrl: string) => {
+      const encodedUrl = encodeURIComponent(appUrl);
+      const ref = encodeURIComponent(typeof window !== 'undefined' ? window.location.origin : 'https://tradefight.club');
+      return `https://solflare.com/ul/v1/browse/${encodedUrl}?ref=${ref}`;
+    },
+    downloadUrl: 'https://solflare.com/download',
+  },
+];
 
 /**
  * Generate a Phantom universal link to open a URL in Phantom's dApp browser


### PR DESCRIPTION
- MobilePhantomRedirect now shows a non-dismissable modal forcing users to open TFC inside Phantom or Solflare dApp browser
- WalletProvider always offers both Phantom and Solflare adapters, removing device-specific wallet config and SolanaMobileWalletAdapter
- WalletButton simplified: mobile wallet selection handled by the modal