### PR TITLE
feat: mandatory wallet selector modal on mobile + simplify wallet config

### DIFF
--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -12,6 +12,7 @@ import { NotificationBell } from '@/components/NotificationBell';
 import { PrizesBanner } from '@/components/PrizesBanner';
 import { WithdrawModal } from '@/components/WithdrawModal';
 import { MobilePhantomRedirect } from '@/components/MobilePhantomRedirect';
+import { NoPacificaModal } from '@/components/NoPacificaModal';
 import { QuickPositionsBar, QuickPositionsDropdown } from '@/components/QuickPositionsBar';
 import { SettingsModal } from '@/components/SettingsModal';
 import { api } from '@/lib/api';
@@ -449,6 +450,9 @@ export function AppShell({ children }: AppShellProps) {
         isOpen={showSettings}
         onClose={() => setShowSettings(false)}
       />
+
+      {/* No Pacifica Account Modal - shown when authenticated but no Pacifica account */}
+      <NoPacificaModal />
 
       {/* Mobile Phantom Redirect - prompts mobile users to open in Phantom dApp browser */}
       <MobilePhantomRedirect />

--- a/apps/web/src/components/NoPacificaModal.tsx
+++ b/apps/web/src/components/NoPacificaModal.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useAuth } from '@/hooks';
+
+const PACIFICA_DEPOSIT_URL = 'https://app.pacifica.fi/trade/BTC';
+
+/**
+ * Modal shown when a user is authenticated but has no Pacifica account.
+ * Cannot be dismissed — the user must deposit on Pacifica to continue.
+ */
+export function NoPacificaModal() {
+  const { isAuthenticated, pacificaConnected } = useAuth();
+
+  // Only show when authenticated but no Pacifica account
+  if (!isAuthenticated || pacificaConnected) return null;
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-end sm:items-center justify-center p-0 sm:p-4">
+      {/* Backdrop — no onClick, cannot dismiss */}
+      <div className="absolute inset-0 bg-black/90 backdrop-blur-sm" />
+
+      {/* Modal */}
+      <div className="relative bg-surface-900 border-t border-surface-700 sm:border sm:rounded-2xl rounded-t-2xl p-6 w-full sm:max-w-sm shadow-2xl">
+        {/* Icon */}
+        <div className="w-16 h-16 rounded-full bg-orange-500/20 flex items-center justify-center mx-auto mb-4">
+          <svg className="w-8 h-8 text-orange-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+          </svg>
+        </div>
+
+        <h2 className="text-lg font-bold text-white text-center mb-1">
+          Pacifica Account Required
+        </h2>
+        <p className="text-surface-400 text-xs text-center mb-5">
+          To trade on TFC you need a Pacifica account. Deposit funds on Pacifica to get started.
+        </p>
+
+        {/* Deposit Button */}
+        <a
+          href={PACIFICA_DEPOSIT_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block w-full py-3 bg-primary-500 hover:bg-primary-400 text-white font-semibold rounded-lg transition-colors text-center text-sm"
+        >
+          Deposit on Pacifica
+        </a>
+
+        <p className="text-surface-300 text-xs text-center mt-4">
+          Once you deposit, your account will be linked automatically.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/BetaApplyModal.tsx
+++ b/apps/web/src/components/landing/BetaApplyModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { WalletMultiButton } from '@solana/wallet-adapter-react-ui';
 import { useBetaAccess } from '@/hooks';
@@ -10,8 +11,9 @@ interface BetaApplyModalProps {
 }
 
 export function BetaApplyModal({ isOpen, onClose }: BetaApplyModalProps) {
+  const router = useRouter();
   const { connected, publicKey } = useWallet();
-  const { status, applied, isApplying, applyForBeta, hasAccess } = useBetaAccess();
+  const { status, applied, isApplying, applyForBeta, hasAccess, refetch } = useBetaAccess();
 
   if (!isOpen) return null;
 
@@ -85,7 +87,7 @@ export function BetaApplyModal({ isOpen, onClose }: BetaApplyModalProps) {
                 </p>
               </div>
               <button
-                onClick={onClose}
+                onClick={() => { onClose(); router.push('/trade'); }}
                 className="w-full py-3 bg-primary-500 hover:bg-primary-400 text-white font-semibold rounded-lg transition-colors"
               >
                 Start Trading
@@ -105,6 +107,15 @@ export function BetaApplyModal({ isOpen, onClose }: BetaApplyModalProps) {
                   Your application for <span className="text-primary-400 font-mono">{shortenedAddress}</span> is being reviewed. We'll notify you when you're approved.
                 </p>
               </div>
+              <button
+                onClick={() => refetch()}
+                className="w-full py-3 bg-orange-500 hover:bg-orange-400 text-white font-semibold rounded-lg transition-colors flex items-center justify-center gap-2"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                Check Access
+              </button>
               <button
                 onClick={onClose}
                 className="w-full py-3 bg-surface-700 hover:bg-surface-600 text-white font-semibold rounded-lg transition-colors"

--- a/apps/web/src/lib/mobile.ts
+++ b/apps/web/src/lib/mobile.ts
@@ -98,7 +98,7 @@ export const MOBILE_WALLETS: MobileWallet[] = [
   {
     id: 'phantom',
     name: 'Phantom',
-    icon: '/wallets/phantom.svg',
+    icon: '/images/landing/walletConnection/Phantom.png',
     getDeepLink: (appUrl: string) => {
       const encodedUrl = encodeURIComponent(appUrl);
       return `phantom://browse/${encodedUrl}`;
@@ -108,7 +108,7 @@ export const MOBILE_WALLETS: MobileWallet[] = [
   {
     id: 'solflare',
     name: 'Solflare',
-    icon: '/wallets/solflare.svg',
+    icon: '/images/landing/walletConnection/Solflare.png',
     getDeepLink: (appUrl: string) => {
       const encodedUrl = encodeURIComponent(appUrl);
       const ref = encodeURIComponent(typeof window !== 'undefined' ? window.location.origin : 'https://tradefight.club');


### PR DESCRIPTION
- MobilePhantomRedirect now shows a non-dismissable modal forcing users to open TFC inside Phantom or Solflare dApp browser
- WalletProvider always offers both Phantom and Solflare adapters, removing device-specific wallet config and SolanaMobileWalletAdapter
- WalletButton simplified: mobile wallet selection handled by the modal