### PR TITLE
Fix Pacifica account verification - always verify on login

### DIFF
--- a/apps/web/src/app/trade/page.tsx
+++ b/apps/web/src/app/trade/page.tsx
@@ -36,7 +36,7 @@ const TRADECLUB_FEE = 0.0005; // 0.05% builder fee
 
 export default function TradePage() {
   const { connected } = useWallet();
-  const { isAuthenticated, pacificaConnected } = useAuth();
+  const { isAuthenticated, pacificaConnected, pacificaFailReason } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -1711,8 +1711,25 @@ export default function TradePage() {
             </div>
             <div className="p-1 flex-1 overflow-y-auto overscroll-y-auto">
 
+              {/* Pacifica Beta Access Required Warning */}
+              {isAuthenticated && !pacificaConnected && pacificaFailReason === 'beta_required' && (
+                <div className="mb-3 xl:mb-4 p-2 xl:p-3 bg-orange-500/10 rounded border border-orange-500/30">
+                  <div className="text-[10px] xl:text-xs text-orange-400 font-semibold mb-1.5 xl:mb-2 uppercase">Beta Access Required</div>
+                  <p className="text-[10px] xl:text-xs text-surface-400 mb-2">
+                    Your wallet needs Pacifica beta access. Request a code from Pacifica.
+                  </p>
+                  <a
+                    href="https://pacifica.fi"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block w-full py-1.5 bg-orange-500 hover:bg-orange-400 text-white text-[10px] font-semibold rounded transition-colors text-center"
+                  >
+                    Visit Pacifica
+                  </a>
+                </div>
+              )}
               {/* No Pacifica Account Warning */}
-              {isAuthenticated && !pacificaConnected && (
+              {isAuthenticated && !pacificaConnected && pacificaFailReason !== 'beta_required' && (
                 <div className="mb-3 xl:mb-4 p-2 xl:p-3 bg-surface-800 rounded border-surface-700">
                   <div className="text-[10px] xl:text-xs text-surface-300 font-semibold mb-1.5 xl:mb-2 uppercase">No Pacifica Account</div>
                   <p className="text-[10px] xl:text-xs text-surface-400 mb-2">

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -70,7 +70,7 @@ function removeProviderListener(
 
 export function useAuth() {
   const { publicKey, signMessage, connected, connecting, disconnect, wallet } = useWallet();
-  const { token, user, walletAddress: storedWalletAddress, isAuthenticated, pacificaConnected, setAuth, setPacificaConnected, clearAuth, _hasHydrated } = useAuthStore();
+  const { token, user, walletAddress: storedWalletAddress, isAuthenticated, pacificaConnected, pacificaFailReason, setAuth, setPacificaConnected, clearAuth, _hasHydrated } = useAuthStore();
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const hasAttemptedAuth = useRef(false);
   const currentWalletAddress = publicKey?.toBase58() || null;
@@ -108,8 +108,8 @@ export function useAuth() {
         clearStoredReferralCode();
       }
 
-      // Store auth state including Pacifica connection status AND wallet address
-      setAuth(response.token, response.user, response.pacificaConnected, publicKey.toBase58());
+      // Store auth state including Pacifica connection status, wallet address, and fail reason
+      setAuth(response.token, response.user, response.pacificaConnected, publicKey.toBase58(), response.pacificaFailReason);
 
       return response;
     } catch (error) {
@@ -274,6 +274,7 @@ export function useAuth() {
     user,
     isAuthenticated,
     pacificaConnected,
+    pacificaFailReason,
     isAuthenticating,
     isConnecting: connecting,
     isWalletConnected: connected,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -50,11 +50,13 @@ async function fetchApi<T>(endpoint: string, options: ApiOptions = {}): Promise<
 // Auth
 // ─────────────────────────────────────────────────────────────
 
+export type PacificaFailReason = 'not_found' | 'beta_required' | null;
+
 export async function connectWallet(
   walletAddress: string,
   signature: string,
   referralCode?: string
-): Promise<{ token: string; user: User; pacificaConnected: boolean }> {
+): Promise<{ token: string; user: User; pacificaConnected: boolean; pacificaFailReason: PacificaFailReason }> {
   return fetchApi('/auth/connect', {
     method: 'POST',
     body: JSON.stringify({ walletAddress, signature, referralCode }),

--- a/apps/web/src/lib/store.ts
+++ b/apps/web/src/lib/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import type { PacificaFailReason } from './api';
 
 export interface User {
   id: string;
@@ -15,9 +16,10 @@ interface AuthState {
   isAuthenticated: boolean;
   isAdmin: boolean;
   pacificaConnected: boolean;
+  pacificaFailReason: PacificaFailReason;
   _hasHydrated: boolean;
 
-  setAuth: (token: string, user: User, pacificaConnected: boolean, walletAddress: string) => void;
+  setAuth: (token: string, user: User, pacificaConnected: boolean, walletAddress: string, pacificaFailReason?: PacificaFailReason) => void;
   setPacificaConnected: (connected: boolean) => void;
   clearAuth: () => void;
   setHasHydrated: (state: boolean) => void;
@@ -32,9 +34,10 @@ export const useAuthStore = create<AuthState>()(
       isAuthenticated: false,
       isAdmin: false,
       pacificaConnected: false,
+      pacificaFailReason: null,
       _hasHydrated: false,
 
-      setAuth: (token, user, pacificaConnected, walletAddress) =>
+      setAuth: (token, user, pacificaConnected, walletAddress, pacificaFailReason = null) =>
         set({
           token,
           user,
@@ -42,10 +45,11 @@ export const useAuthStore = create<AuthState>()(
           isAuthenticated: true,
           isAdmin: user.role === 'ADMIN',
           pacificaConnected,
+          pacificaFailReason,
         }),
 
       setPacificaConnected: (connected) =>
-        set({ pacificaConnected: connected }),
+        set({ pacificaConnected: connected, pacificaFailReason: connected ? null : undefined }),
 
       clearAuth: () =>
         set({
@@ -55,6 +59,7 @@ export const useAuthStore = create<AuthState>()(
           isAuthenticated: false,
           isAdmin: false,
           pacificaConnected: false,
+          pacificaFailReason: null,
         }),
 
       setHasHydrated: (state) => set({ _hasHydrated: state }),
@@ -68,6 +73,7 @@ export const useAuthStore = create<AuthState>()(
         isAuthenticated: state.isAuthenticated,
         isAdmin: state.isAdmin,
         pacificaConnected: state.pacificaConnected,
+        pacificaFailReason: state.pacificaFailReason,
       }),
       onRehydrateStorage: () => (state) => {
         state?.setHasHydrated(true);


### PR DESCRIPTION
Changes:
- Always call Pacifica API on every login to sync DB state
- Add pacificaFailReason to distinguish between 'not_found' and 'beta_required'
- Show different UI messages based on failure reason:
  - not_found: "Deposit on Pacifica" (red banner)
  - beta_required: "Request Pacifica beta code" (orange banner)
- Update pacifica_connections.isActive based on actual Pacifica API response
- Fix pending beta access status not updating after approval

Files modified:
- auth.ts: Always verify with Pacifica, return fail reason
- api.ts: Add PacificaFailReason type
- store.ts: Persist pacificaFailReason in auth state
- useAuth.ts: Expose pacificaFailReason
- trade/page.tsx: Show context-specific error messages
- useBetaAccess.ts: Fix pending status cache handling