### PR TITLE
fix(auth): Add pacificaFailReason to authenticateWallet return type

### DIFF
--- a/apps/web/src/lib/server/services/auth.ts
+++ b/apps/web/src/lib/server/services/auth.ts
@@ -182,6 +182,7 @@ export async function authenticateWallet(
   token: string;
   user: { id: string; handle: string; avatarUrl: string | null; role: 'USER' | 'ADMIN' };
   pacificaConnected: boolean;
+  pacificaFailReason: 'not_found' | 'beta_required' | null;
 }> {
   console.log('Wallet authentication attempt', {
     walletAddress: walletAddress.slice(0, 8) + '...',


### PR DESCRIPTION
The function was already computing and returning pacificaFailReason but the Promise return type annotation was missing the property, causing build failure.