### PR TITLE
feat(landing): Add Alpha Testing application form link to hero section

### DIFF
--- a/apps/web/src/components/landing/HeroSection.tsx
+++ b/apps/web/src/components/landing/HeroSection.tsx
@@ -76,6 +76,14 @@ export function HeroSection() {
               >
                 Join Beta
               </button>
+              <a
+                href="https://forms.gle/9nR9tYmf5imJG8Ck6"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="w-full sm:w-auto text-center px-6 py-3 bg-white text-surface-900 hover:bg-surface-200 font-semibold rounded-lg transition-colors"
+              >
+                Apply for Alpha Testing
+              </a>
             </div>
 
             {/* Stats Row */}


### PR DESCRIPTION
Adds a white CTA button next to "Join Beta" that links to the Google Form for alpha tester recruitment.