### PR TITLE
fix: force Pacifica status re-check on returning sessions

### DIFF
--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -185,6 +185,8 @@ export function useAuth() {
     if (isAuthenticated && storedWalletAddress === currentWalletAddress) {
       hasAttemptedAuth.current = true;
       globalHasAttempted = true;
+      // Force immediate Pacifica status re-check — stored value may be stale
+      queryClient.invalidateQueries({ queryKey: ['pacifica-connection'] });
       return;
     }
 


### PR DESCRIPTION
When a user returns with the same wallet already authenticated, invalidate the pacifica-connection query immediately instead of waiting for the 10s poll interval. Fixes stale pacificaConnected state in localStorage when users create Pacifica accounts externally.