### PR TITLE
feat: add Cross/Isolated margin mode toggle with confirmation modal

### DIFF
--- a/apps/web/src/app/api/account/margin/route.ts
+++ b/apps/web/src/app/api/account/margin/route.ts
@@ -1,0 +1,55 @@
+/**
+ * Account Margin Mode endpoint
+ * POST /api/account/margin - Switch between cross and isolated margin for a trading pair
+ */
+import { errorResponse, BadRequestError, ServiceUnavailableError } from '@/lib/server/errors';
+import { ErrorCode } from '@/lib/server/error-codes';
+
+const PACIFICA_API_URL = process.env.PACIFICA_API_URL || 'https://api.pacifica.fi';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { account, symbol, is_isolated, signature, timestamp } = body;
+
+    if (!account || !symbol || is_isolated === undefined || !signature || !timestamp) {
+      throw new BadRequestError('account, symbol, is_isolated, signature, and timestamp are required', ErrorCode.ERR_VALIDATION_MISSING_FIELD);
+    }
+
+    console.log('Setting margin mode:', { account, symbol, is_isolated });
+
+    // Proxy to Pacifica API
+    const response = await fetch(`${PACIFICA_API_URL}/api/v1/account/margin`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        account,
+        symbol,
+        is_isolated,
+        signature,
+        timestamp,
+        expiry_window: 5000,
+      }),
+    });
+
+    const responseText = await response.text();
+    console.log('Pacifica margin mode response:', { status: response.status, body: responseText });
+
+    let result;
+    try {
+      result = JSON.parse(responseText);
+    } catch {
+      throw new ServiceUnavailableError(`Failed to parse Pacifica response: ${responseText}`, ErrorCode.ERR_EXTERNAL_PACIFICA_API);
+    }
+
+    if (!response.ok || !result.success) {
+      throw new ServiceUnavailableError(result.error || `Pacifica API error: ${response.status}`, ErrorCode.ERR_EXTERNAL_PACIFICA_API);
+    }
+
+    console.log('Margin mode set successfully', { account, symbol, is_isolated });
+
+    return Response.json({ success: true, data: result.data });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -9,7 +9,7 @@ export { useOrderBook } from './useOrderBook';
 export type { AggLevel } from './useOrderBook';
 export { useCandles } from './useCandles';
 export type { CandleData } from './useCandles';
-export { useCreateMarketOrder, useCreateLimitOrder, useCancelOrder, useCancelStopOrder, useCancelAllOrders, useSetPositionTpSl, useCreateStopOrder, useCreateStandaloneStopOrder, useSetLeverage, useWithdraw, useEditOrder } from './useOrders';
+export { useCreateMarketOrder, useCreateLimitOrder, useCancelOrder, useCancelStopOrder, useCancelAllOrders, useSetPositionTpSl, useCreateStopOrder, useCreateStandaloneStopOrder, useSetLeverage, useSetMarginMode, useWithdraw, useEditOrder } from './useOrders';
 export { usePositions, useAccountInfo, useAccountSettings, useOpenOrders, useMarkets, useMarket, useTradeHistory, useOrderHistory } from './usePositions';
 export { usePacificaConnection } from './usePacificaConnection';
 export { useBuilderCodeStatus, useApproveBuilderCode, getBuilderCode } from './useBuilderCode';

--- a/apps/web/src/lib/pacifica/signing.ts
+++ b/apps/web/src/lib/pacifica/signing.ts
@@ -258,6 +258,23 @@ export async function createSignedUpdateLeverage(
 }
 
 /**
+ * Sign margin mode update (cross/isolated)
+ * NOTE: account is NOT included in signed data
+ */
+export async function createSignedUpdateMarginMode(
+  wallet: WalletContextState,
+  params: {
+    symbol: string;
+    is_isolated: boolean;
+  }
+): Promise<SignedOperation> {
+  return signPacificaOperation(wallet, 'update_margin_mode', {
+    symbol: params.symbol,
+    is_isolated: params.is_isolated,
+  });
+}
+
+/**
  * Sign TP/SL update
  * NOTE: account is NOT included in signed data (same as market orders)
  * NOTE: null values are used to remove TP/SL


### PR DESCRIPTION
Add ability to switch between Cross and Isolated margin modes per trading pair, following the existing leverage update pattern with wallet signing and Pacifica API proxy.