### PR TITLE
fix: fill candle gaps from sparse Pacifica data

### DIFF
--- a/apps/web/src/app/api/chart/candles/route.ts
+++ b/apps/web/src/app/api/chart/candles/route.ts
@@ -457,6 +457,40 @@ function mergeCandles(historical: Candle[], recent: Candle[]): Candle[] {
   return Array.from(map.values()).sort((a, b) => a.t - b.t);
 }
 
+// Fill gaps in candle data with synthetic candles (OHLC = previous close, volume = 0)
+function fillCandleGaps(candles: Candle[], interval: string): Candle[] {
+  if (candles.length < 2) return candles;
+
+  const intervalMs = getIntervalMs(interval);
+  const filled: Candle[] = [candles[0]];
+
+  for (let i = 1; i < candles.length; i++) {
+    const prev = filled[filled.length - 1];
+    const curr = candles[i];
+
+    const gap = curr.t - prev.t;
+    const missingCount = Math.round(gap / intervalMs) - 1;
+
+    // Fill gaps (cap at 1000 to avoid memory issues on large ranges)
+    if (missingCount > 0 && missingCount <= 1000) {
+      for (let j = 1; j <= missingCount; j++) {
+        filled.push({
+          t: prev.t + j * intervalMs,
+          o: prev.c,
+          h: prev.c,
+          l: prev.c,
+          c: prev.c,
+          v: 0,
+        });
+      }
+    }
+
+    filled.push(curr);
+  }
+
+  return filled;
+}
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
@@ -560,15 +594,21 @@ export async function GET(request: Request) {
       }
     }
 
+    // Fill gaps in the final candle data to ensure continuous chart display
+    const filledCandles = fillCandleGaps(candles, interval);
+    if (filledCandles.length !== candles.length) {
+      console.log(`[Chart] Gap fill: ${candles.length} → ${filledCandles.length} candles (+${filledCandles.length - candles.length} synthetic)`);
+    }
+
     return Response.json({
       success: true,
-      data: candles,
+      data: filledCandles,
       meta: {
         symbol,
         interval,
         startTime,
         endTime,
-        count: candles.length,
+        count: filledCandles.length,
       },
     });
   } catch (error) {

--- a/apps/web/src/components/TradingViewChartAdvanced.tsx
+++ b/apps/web/src/components/TradingViewChartAdvanced.tsx
@@ -18,35 +18,6 @@ interface ChartWidget {
   setSymbol: (symbol: string, resolution: string, callback?: () => void) => void;
   remove: () => void;
   subscribe: (event: string, callback: (...args: unknown[]) => void) => void;
-  save: (callback: (data: object) => void) => void;
-  load: (data: object) => void;
-}
-
-// LocalStorage key for chart data
-const CHART_STORAGE_KEY = 'tfc_tradingview_chart_data';
-
-// Save chart data to localStorage
-function saveChartData(data: object): void {
-  try {
-    localStorage.setItem(CHART_STORAGE_KEY, JSON.stringify(data));
-    console.log('[TradingView] Chart data saved');
-  } catch (error) {
-    console.error('[TradingView] Failed to save chart data:', error);
-  }
-}
-
-// Load chart data from localStorage
-function loadChartData(): object | null {
-  try {
-    const data = localStorage.getItem(CHART_STORAGE_KEY);
-    if (data) {
-      console.log('[TradingView] Chart data loaded from storage');
-      return JSON.parse(data);
-    }
-  } catch (error) {
-    console.error('[TradingView] Failed to load chart data:', error);
-  }
-  return null;
 }
 
 function TradingViewChartAdvancedComponent({
@@ -126,12 +97,6 @@ function TradingViewChartAdvancedComponent({
         foregroundColor: '#6366f1',
       },
 
-      // Auto-save settings (save after 1 second of inactivity)
-      auto_save_delay: 1,
-
-      // Load saved chart data if available
-      saved_data: loadChartData(),
-
       overrides: {
         'paneProperties.background': '#111113',
         'paneProperties.backgroundGradientStartColor': '#111113',
@@ -207,12 +172,6 @@ function TradingViewChartAdvancedComponent({
           }
         });
 
-        // Subscribe to auto-save events to persist chart data
-        widget.subscribe('onAutoSaveNeeded', () => {
-          widget.save((data: object) => {
-            saveChartData(data);
-          });
-        });
       });
     } catch (error) {
       console.error('[TradingView] Failed to create widget:', error);


### PR DESCRIPTION
Pacifica's kline API returns sparse candles (missing periods with no trades). This causes visible gaps in the TradingView chart on 1m/3m timeframes.

- Add gap filling on server side (chart candles API) and client side (TradingView datafeed) with synthetic candles (OHLC = prev close, v=0)
- Subscribe to mark_price_candle WebSocket for continuous real-time updates even during low-liquidity periods
- Add has_empty_bars: false to symbol info
- Remove stale localStorage chart state that was persisting old gaps