### PR TITLE
fix: switch chart to mark price candles to eliminate gaps

### DIFF
--- a/apps/web/src/app/api/chart/candles/route.ts
+++ b/apps/web/src/app/api/chart/candles/route.ts
@@ -303,13 +303,24 @@ async function fetchFromPacifica(
       }));
     }
 
-    // Fallback to direct Pacifica calls
-    const rawCandles = await Pacifica.getKlines({
-      symbol: pacificaSymbol,
-      interval,
-      startTime,
-      endTime,
-    });
+    // Fallback to direct Pacifica calls (prefer mark price klines - no gaps)
+    let rawCandles;
+    try {
+      rawCandles = await Pacifica.getMarkPriceKlines({
+        symbol: pacificaSymbol,
+        interval,
+        startTime,
+        endTime,
+      });
+    } catch {
+      // Fall back to regular klines if mark price endpoint fails
+      rawCandles = await Pacifica.getKlines({
+        symbol: pacificaSymbol,
+        interval,
+        startTime,
+        endTime,
+      });
+    }
 
     return rawCandles.map(c => ({
       t: c.t,

--- a/apps/web/src/lib/server/pacifica.ts
+++ b/apps/web/src/lib/server/pacifica.ts
@@ -98,7 +98,7 @@ export async function getOrderbook(symbol: string, aggLevel = 1): Promise<Orderb
 }
 
 /**
- * Get historical candles
+ * Get historical candles (last traded price)
  * GET /api/v1/kline
  */
 export async function getKlines(params: {
@@ -108,6 +108,25 @@ export async function getKlines(params: {
   endTime?: number;
 }): Promise<Candle[]> {
   let url = `/api/v1/kline?symbol=${params.symbol}&interval=${params.interval}&start_time=${params.startTime}`;
+
+  if (params.endTime) {
+    url += `&end_time=${params.endTime}`;
+  }
+
+  return request<Candle[]>('GET', url);
+}
+
+/**
+ * Get historical mark price candles (continuous, no gaps)
+ * GET /api/v1/mark_price_kline
+ */
+export async function getMarkPriceKlines(params: {
+  symbol: string;
+  interval: string;
+  startTime: number;
+  endTime?: number;
+}): Promise<Candle[]> {
+  let url = `/api/v1/mark_price_kline?symbol=${params.symbol}&interval=${params.interval}&start_time=${params.startTime}`;
 
   if (params.endTime) {
     url += `&end_time=${params.endTime}`;


### PR DESCRIPTION
Use mark_price_candle (continuous) instead of last traded price candles which have gaps when no trades occur on 1m/3m intervals.

- WebSocket: subscribe only to mark_price_candle channel
- REST API: add getMarkPriceKlines() calling /api/v1/mark_price_kline
- Exchange adapter & candles route: prefer mark price with fallback