### PR TITLE
fix: fight session flow — lobby stale flash, resolving spinner, video…

### DIFF
--- a/apps/realtime/src/fight-engine.ts
+++ b/apps/realtime/src/fight-engine.ts
@@ -1525,6 +1525,7 @@ export class FightEngine {
         finalPnlPercent: p.finalPnlPercent,
         finalScoreUsdc: p.finalScoreUsdc,
         tradesCount: p.tradesCount,
+        blockedSymbols: p.blockedSymbols || [],
         user: {
           id: p.user.id,
           handle: p.user.handle,

--- a/apps/web/src/components/FightCard.tsx
+++ b/apps/web/src/components/FightCard.tsx
@@ -39,12 +39,22 @@ export function FightCard({ fight, compact = false, onJoinFight, onCancelFight }
       const updatedFight = await onJoinFight(fight.id);
 
       console.log('[FightCard] API success! Starting video overlay...');
-      // API verified matchup limits - NOW start the video
       startVideo();
 
-      // Redirect happens independently (video plays over the transition)
+      // Build URL with safe initial symbol (avoid blocked assets)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const myParticipant = updatedFight.participants?.find((p: any) => p.userId === user?.id);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const blocked: string[] = (myParticipant as any)?.blockedSymbols || [];
+      let url = `/trade?fight=${updatedFight.id}`;
+      if (blocked.length > 0) {
+        const safe = ['BTC-USD', 'ETH-USD', 'SOL-USD', 'DOGE-USD', 'HYPE-USD']
+          .find(s => !blocked.includes(s));
+        if (safe && safe !== 'BTC-USD') url += `&symbol=${safe}`;
+      }
+
       console.log('[FightCard] Redirecting to terminal...');
-      router.push(`/trade?fight=${updatedFight.id}`);
+      router.push(url);
     } catch (err) {
       console.error('[FightCard] Failed to join fight:', err);
       // Error is shown as a toast by useFights hook

--- a/apps/web/src/components/GlobalFightVideo.tsx
+++ b/apps/web/src/components/GlobalFightVideo.tsx
@@ -1,79 +1,127 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useVideoStore } from '@/lib/stores/videoStore';
+import { Spinner } from './Spinner';
 
 const MIN_DURATION = 5000; // Match video duration (5 seconds)
+const VIDEO_SRC = '/Video/Fight_intro_video.webm';
+
+// Module-level blob cache — survives component remounts and SPA navigations.
+// The 1.8MB video is fetched once and reused for every fight.
+let cachedBlobUrl: string | null = null;
+let fetchPromise: Promise<string> | null = null;
+
+function prefetchVideo(): Promise<string> {
+  if (cachedBlobUrl) return Promise.resolve(cachedBlobUrl);
+  if (fetchPromise) return fetchPromise;
+
+  fetchPromise = fetch(VIDEO_SRC)
+    .then(res => res.blob())
+    .then(blob => {
+      cachedBlobUrl = URL.createObjectURL(blob);
+      console.log('[GlobalFightVideo] Video prefetched into blob');
+      return cachedBlobUrl;
+    })
+    .catch(err => {
+      console.warn('[GlobalFightVideo] Prefetch failed, falling back to URL:', err);
+      fetchPromise = null;
+      return VIDEO_SRC; // fallback to network URL
+    });
+
+  return fetchPromise;
+}
 
 /**
  * GlobalFightVideo - Global video overlay shown when joining a fight
- * Plays independently of page transitions and state changes
- * Enforces minimum duration before closing
+ *
+ * On mount, the video is fetched via JS fetch() into a Blob URL (module-level
+ * cache). This guarantees the 1.8MB file is fully in memory before playback.
+ * When startVideo() is called, playback is instant.
+ *
+ * The video element is ALWAYS rendered (hidden via CSS when not playing)
+ * so the blob src is ready immediately when needed.
+ *
+ * The video starts MUTED to bypass browser autoplay policy (which blocks
+ * unmuted autoplay from non-user-gesture contexts like WebSocket handlers).
+ * It unmutes immediately after play() succeeds.
  */
 export function GlobalFightVideo() {
   const { isPlaying, stopVideo } = useVideoStore();
   const videoRef = useRef<HTMLVideoElement>(null);
   const startTimeRef = useRef<number>(0);
   const hasEndedRef = useRef(false);
+  const [blobSrc, setBlobSrc] = useState<string | null>(cachedBlobUrl);
+  const [isBuffering, setIsBuffering] = useState(true);
 
+  // Prefetch video into blob on mount
   useEffect(() => {
-    if (isPlaying && videoRef.current) {
-      const video = videoRef.current;
+    prefetchVideo().then(url => setBlobSrc(url));
+  }, []);
 
-      // Reset state and record start time
-      hasEndedRef.current = false;
-      startTimeRef.current = Date.now();
-      video.currentTime = 0;
+  // Track when video has enough data to play through
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
 
-      console.log('[GlobalFightVideo] Starting video playback');
+    const markReady = () => setIsBuffering(false);
 
-      // Play the video
-      const playPromise = video.play();
-
-      if (playPromise !== undefined) {
-        playPromise
-          .then(() => {
-            console.log('[GlobalFightVideo] Video playing, duration:', video.duration);
-          })
-          .catch((error) => {
-            console.error('[GlobalFightVideo] Video autoplay failed:', error);
-            // If autoplay fails, still wait minimum duration then close
-            setTimeout(() => {
-              if (!hasEndedRef.current) {
-                hasEndedRef.current = true;
-                stopVideo();
-              }
-            }, MIN_DURATION);
-          });
-      }
+    if (video.readyState >= 3) {
+      setIsBuffering(false);
     }
-  }, [isPlaying, stopVideo]);
 
-  // Handle video end - enforce minimum duration
+    video.addEventListener('canplaythrough', markReady);
+    return () => video.removeEventListener('canplaythrough', markReady);
+  }, [blobSrc]); // re-run when blob src changes
+
+  // Start playback when isPlaying becomes true
+  useEffect(() => {
+    if (!isPlaying || !videoRef.current || !blobSrc) return;
+
+    const video = videoRef.current;
+    hasEndedRef.current = false;
+    startTimeRef.current = Date.now();
+    video.currentTime = 0;
+
+    // Start muted to guarantee autoplay works (browser policy blocks
+    // unmuted autoplay from non-user-gesture contexts like WebSocket events).
+    video.muted = true;
+
+    const playPromise = video.play();
+    if (playPromise !== undefined) {
+      playPromise
+        .then(() => {
+          // Unmute after play starts
+          video.muted = false;
+          console.log('[GlobalFightVideo] Playing, duration:', video.duration);
+        })
+        .catch((err) => {
+          console.warn('[GlobalFightVideo] Play failed:', err);
+          setTimeout(() => {
+            if (!hasEndedRef.current) {
+              hasEndedRef.current = true;
+              stopVideo();
+            }
+          }, MIN_DURATION);
+        });
+    }
+  }, [isPlaying, stopVideo, blobSrc]);
+
+  // Pause and re-mute video when overlay closes
+  useEffect(() => {
+    if (!isPlaying && videoRef.current) {
+      videoRef.current.pause();
+      videoRef.current.muted = true;
+
+      // Force TradingView chart to re-render
+      requestAnimationFrame(() => {
+        window.dispatchEvent(new Event('resize'));
+      });
+    }
+  }, [isPlaying]);
+
+  // Enforce minimum duration on video end
   const handleVideoEnd = () => {
-    if (hasEndedRef.current) {
-      console.log('[GlobalFightVideo] Video already ended, skipping duplicate call');
-      return;
-    }
-
-    const elapsed = Date.now() - startTimeRef.current;
-    const remaining = Math.max(0, MIN_DURATION - elapsed);
-
-    console.log(`[GlobalFightVideo] Video ended after ${elapsed}ms, waiting ${remaining}ms more`);
-
-    setTimeout(() => {
-      if (!hasEndedRef.current) {
-        hasEndedRef.current = true;
-        console.log('[GlobalFightVideo] Closing video overlay');
-        stopVideo();
-      }
-    }, remaining);
-  };
-
-  // Handle video error - close after minimum duration
-  const handleVideoError = (e: React.SyntheticEvent<HTMLVideoElement>) => {
-    console.error('[GlobalFightVideo] Video error:', e);
-
     if (hasEndedRef.current) return;
 
     const elapsed = Date.now() - startTimeRef.current;
@@ -87,32 +135,65 @@ export function GlobalFightVideo() {
     }, remaining);
   };
 
-  if (!isPlaying) return null;
+  // Handle video error — still wait minimum duration
+  const handleVideoError = () => {
+    if (hasEndedRef.current) return;
+
+    const elapsed = Date.now() - startTimeRef.current;
+    const remaining = Math.max(0, MIN_DURATION - elapsed);
+
+    setTimeout(() => {
+      if (!hasEndedRef.current) {
+        hasEndedRef.current = true;
+        stopVideo();
+      }
+    }, remaining);
+  };
 
   return (
     <>
-      {/* Backdrop - z-index 9998 */}
-      <div className="fixed inset-0 bg-black/90 backdrop-blur-sm z-[9998]" />
+      {/* Backdrop + modal — only visible when playing */}
+      {isPlaying && (
+        <>
+          <div className="fixed inset-0 bg-black/90 backdrop-blur-sm z-[9998]" />
+          <div className="fixed inset-0 z-[9999] flex items-center justify-center p-4">
+            <div className="relative bg-surface-900 rounded-xl shadow-2xl max-w-4xl w-full overflow-hidden border border-surface-800" />
+          </div>
+        </>
+      )}
 
-      {/* Modal - z-index 9999 */}
-      <div className="fixed inset-0 z-[9999] flex items-center justify-center p-4 pointer-events-none">
-        <div className="relative bg-surface-900 rounded-xl shadow-2xl max-w-4xl w-full overflow-hidden border border-surface-800 pointer-events-auto">
-          {/* Video */}
-          <video
-            ref={videoRef}
-            onEnded={handleVideoEnd}
-            onError={handleVideoError}
-            className="w-full h-auto"
-            playsInline
-            muted={false}
-            preload="auto"
-            controls={false}
-          >
-            <source src="/Video/Fight_intro_video.webm" type="video/webm" />
-            Your browser does not support the video tag.
-          </video>
+      {/*
+        Single video element — ALWAYS in DOM with blob src.
+        When playing: positioned centered over the modal.
+        When not playing: hidden off-screen (1x1px, invisible).
+      */}
+      {blobSrc && (
+        <video
+          ref={videoRef}
+          onEnded={handleVideoEnd}
+          onError={handleVideoError}
+          className={
+            isPlaying
+              ? 'fixed z-[10000] top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 max-w-4xl w-[calc(100%-2rem)] rounded-xl'
+              : 'fixed w-px h-px opacity-0 pointer-events-none -z-50 top-0 left-0'
+          }
+          playsInline
+          muted
+          preload="auto"
+          controls={false}
+          src={blobSrc}
+        />
+      )}
+
+      {/* Buffering spinner — shows inside modal when video isn't ready */}
+      {isPlaying && isBuffering && (
+        <div className="fixed z-[10001] top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+          <div className="flex flex-col items-center gap-3">
+            <Spinner size="lg" />
+            <span className="text-surface-400 text-sm font-medium">Get ready to fight...</span>
+          </div>
         </div>
-      </div>
+      )}
     </>
   );
 }

--- a/apps/web/src/components/TradingViewChartAdvanced.tsx
+++ b/apps/web/src/components/TradingViewChartAdvanced.tsx
@@ -158,6 +158,10 @@ function TradingViewChartAdvancedComponent({
         isReadyRef.current = true;
         setIsChartReady(true);
 
+        // Force initial canvas paint even if behind a z-index overlay (e.g., fight video).
+        // TradingView defers canvas rendering when occluded; a resize forces it to draw.
+        setTimeout(() => window.dispatchEvent(new Event('resize')), 100);
+
         widget.subscribe('onSymbolChanged', (...args: unknown[]) => {
           const symbolData = args[0] as { name?: string } | undefined;
           if (symbolData?.name && onSymbolChange) {

--- a/apps/web/src/hooks/useArenaSocket.ts
+++ b/apps/web/src/hooks/useArenaSocket.ts
@@ -1,10 +1,8 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { io, Socket } from 'socket.io-client';
-import { toast } from 'sonner';
-import { useStore, useAuthStore } from '@/lib/store';
+import { useStore } from '@/lib/store';
 import type { Fight } from '@/lib/api';
 
 const SOCKET_URL = process.env.NEXT_PUBLIC_WS_URL || 'http://localhost:3002';
@@ -18,7 +16,6 @@ export function useArenaSocket() {
   const socketRef = useRef<Socket | null>(null);
   const [isConnected, setIsConnected] = useState(false);
   const { addFight, updateFight, removeFight } = useStore();
-  const router = useRouter();
 
   useEffect(() => {
     const socket = io(SOCKET_URL, {
@@ -61,22 +58,7 @@ export function useArenaSocket() {
     socket.on('arena:fight_started', (fight: Fight) => {
       console.log('[Arena] Fight started:', fight.id);
       updateFight(fight);
-
-      // Notify the creator that their fight has started
-      // This notification is persistent (1 min) and visible globally
-      const currentUser = useAuthStore.getState().user;
-      if (currentUser && fight.creator?.id === currentUser.id) {
-        toast.success('Your fight has started!', {
-          description: 'An opponent has joined. Ready to trade?',
-          duration: 60000, // 1 minute - persistent until action
-          action: {
-            label: 'Go to Terminal →',
-            onClick: () => {
-              router.push(`/trade?fight=${fight.id}`);
-            },
-          },
-        });
-      }
+      // Creator notification + video + redirect handled by useGlobalSocket.ts
     });
 
     socket.on('arena:fight_ended', (fight: Fight) => {
@@ -94,7 +76,7 @@ export function useArenaSocket() {
       socket.disconnect();
       socketRef.current = null;
     };
-  }, [addFight, updateFight, removeFight, router]);
+  }, [addFight, updateFight, removeFight]);
 
   return {
     isConnected,

--- a/apps/web/src/hooks/useFight.ts
+++ b/apps/web/src/hooks/useFight.ts
@@ -157,6 +157,15 @@ export function useFight() {
     return () => clearInterval(interval);
   }, [fight]);
 
+  // Show resolving spinner as soon as the client-side timer hits 0
+  // This fires instantly — no need to wait for the server's arena:fight_ended event
+  useEffect(() => {
+    if (!fight || fight.status !== 'LIVE' || !pathname || pathname !== '/trade') return;
+    if (timeRemaining !== null && timeRemaining <= 0 && !isResolving) {
+      setIsResolving(true);
+    }
+  }, [fight, timeRemaining, isResolving, pathname]);
+
   // Redirect when fight ends (LIVE -> FINISHED/CANCELLED)
   // Only redirect if we're on the /trade page with a fight param
   useEffect(() => {
@@ -201,7 +210,7 @@ export function useFight() {
 
       // Only auto-redirect from /trade page
       if (pathname === '/trade') {
-        // Show resolving overlay immediately
+        // Show resolving overlay (may already be true from timer-based trigger above)
         setIsResolving(true);
 
         // Small delay to let user see the final state

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -123,6 +123,8 @@ export interface FightParticipant {
   // External trades detection
   externalTradesDetected: boolean;
   externalTradeIds: string[];
+  // Symbols blocked from trading (pre-fight positions)
+  blockedSymbols?: string[];
 }
 
 export interface User {

--- a/apps/web/src/lib/stores/navigationStore.ts
+++ b/apps/web/src/lib/stores/navigationStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+
+interface NavigationState {
+  router: AppRouterInstance | null;
+  setRouter: (router: AppRouterInstance) => void;
+  navigate: (url: string) => void;
+}
+
+export const useNavigationStore = create<NavigationState>((set, get) => ({
+  router: null,
+  setRouter: (router) => set({ router }),
+  navigate: (url) => {
+    const { router } = get();
+    if (router) {
+      router.push(url);
+    } else {
+      console.warn('[NavigationStore] Router not set, using window.location');
+      window.location.href = url;
+    }
+  },
+}));


### PR DESCRIPTION
… preload, chart render

- Sync React Query cache via setQueryData on fight_started/ended/deleted events to eliminate stale fight flash in lobby when navigating back from other pages
- Trigger resolving spinner immediately when client-side timer hits 0 instead of waiting for server arena:fight_ended event (3-5s delay)
- Preload fight video into blob URL at module level for instant playback; keep video element always in DOM (hidden via CSS) to avoid reload delays
- Use muted autoplay with post-play unmute to bypass browser autoplay policy
- Force TradingView chart canvas repaint via resize event during video overlay
- Replace window.location.href with SPA navigation store for creator redirect
- Remove duplicate arena:fight_started handler in useArenaSocket
- Pass blocked symbols via URL param to avoid asset flash on fight join
- Add fight expiry guard for offline creators