### PR TITLE
ui: mobile fixes — leaderboard fonts, fight banner, tabs, fight capit…

### DIFF
--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -113,7 +113,7 @@ export default function LeaderboardPage() {
         <div className="mb-4">
           <div className="flex items-center justify-between mb-4">
             <div>
-              <h1 className="font-display text-2xl md:text-3xl font-bold tracking-tight text-white">Leaderboard</h1>
+              <h1 className="font-display text-sm sm:text-2xl font-bold tracking-tight text-white">Leaderboard</h1>
             </div>
             <div className="flex items-center gap-3">
               {isFetching && !isLoading && <Spinner size="xs" />}
@@ -152,7 +152,7 @@ export default function LeaderboardPage() {
                 </div>
                 <span className="text-xs text-surface-500">Total Fighters</span>
               </div>
-              <p className="text-2xl md:text-3xl font-bold text-white">{entries.length}</p>
+              <p className="text-sm sm:text-3xl font-bold text-white">{entries.length}</p>
             </div>
 
             {/* Weekly Fees */}
@@ -164,7 +164,7 @@ export default function LeaderboardPage() {
                   </div>
                   <span className="text-xs text-surface-500">Weekly Fees</span>
                 </div>
-                <p className="text-2xl md:text-3xl font-bold text-white">
+                <p className="text-sm sm:text-3xl font-bold text-white">
                   {isPrizePoolLoading ? <span className="inline-block h-8 w-16 bg-surface-700 rounded animate-pulse" /> : formatCurrency(prizePool?.totalFeesCollected || 0)}
                 </p>
               </div>
@@ -179,7 +179,7 @@ export default function LeaderboardPage() {
                   </div>
                   <span className="text-xs text-surface-500">Prize Pool</span>
                 </div>
-                <p className="text-2xl md:text-3xl font-bold text-gradient-orange">
+                <p className="text-sm sm:text-3xl font-bold text-gradient-orange">
                   {isPrizePoolLoading ? <span className="inline-block h-8 w-16 bg-surface-700 rounded animate-pulse" /> : formatCurrency(prizePool?.totalPrizePool || 0)}
                 </p>
               </div>
@@ -194,7 +194,7 @@ export default function LeaderboardPage() {
                   </div>
                   <span className="text-xs text-surface-500">Time Remaining</span>
                 </div>
-                <p className="text-2xl md:text-3xl font-mono font-bold text-white">
+                <p className="text-sm sm:text-3xl font-mono font-bold text-white">
                   {isPrizePoolLoading ? <span className="inline-block h-8 w-16 bg-surface-700 rounded animate-pulse" /> : prizePool?.timeRemaining.formatted || '--'}
                 </p>
               </div>
@@ -206,7 +206,7 @@ export default function LeaderboardPage() {
                   </div>
                   <span className="text-xs text-surface-500">Total Fights</span>
                 </div>
-                <p className="text-2xl md:text-3xl font-bold text-white">
+                <p className="text-sm sm:text-3xl font-bold text-white">
                   {entries.reduce((sum, e) => sum + e.totalFights, 0)}
                 </p>
               </div>

--- a/apps/web/src/app/trade/page.tsx
+++ b/apps/web/src/app/trade/page.tsx
@@ -230,6 +230,8 @@ function TradePageContent() {
 
   // Fight filter toggle (only visible when in active fight)
   const [showFightOnly, setShowFightOnly] = useState(true);
+  // Fight capital limit accordion (collapsed by default)
+  const [showFightCapital, setShowFightCapital] = useState(true);
 
   // Markets and prices from Pacifica API (dynamic, not hardcoded)
   const { markets, getPrice } = usePrices({
@@ -1140,7 +1142,7 @@ function TradePageContent() {
             <div className="col-span-2 order-4 card min-h-[389px] xl:min-h-[400px] flex flex-col overflow-hidden" style={{ contain: 'strict' }}>
               {/* Tab navigation - fixed, scrollable on mobile with overscroll containment */}
               <div className="flex items-center justify-between border-surface-800 flex-shrink-0 overflow-x-auto overscroll-x-auto">
-                <div className="flex items-center gap-3 sm:gap-6 px-4 min-w-max max-[1199px]:min-w-0 max-[1199px]:w-full max-[1199px]:gap-0 max-[1199px]:px-0">
+                <div className="flex items-center gap-3 sm:gap-6 px-2 sm:px-4 max-[1199px]:min-w-0 max-[1199px]:w-full max-[1199px]:gap-0 min-w-max max-[1199px]:min-w-0">
                   <button
                     onClick={() => setBottomTab('positions')}
                     className={`py-3 text-xs font-medium border-b-2 transition-colors whitespace-nowrap max-[1199px]:flex-1 max-[1199px]:text-center ${bottomTab === 'positions'
@@ -1185,10 +1187,10 @@ function TradePageContent() {
 
                 {/* Fight filter toggle - only show when in active fight */}
                 {fightId && (
-                  <div className="flex items-center gap-1 bg-surface-800 rounded-lg p-1 mx-4 flex-shrink-0">
+                  <div className="flex items-center gap-1 bg-surface-800 rounded-lg p-0.5 sm:p-1 mr-2 sm:mx-4 flex-shrink-0">
                     <button
                       onClick={() => setShowFightOnly(false)}
-                      className={`px-3 py-1.5 text-xs font-medium rounded transition-colors ${!showFightOnly
+                      className={`px-2 sm:px-3 py-1 sm:py-1.5 text-[10px] sm:text-xs font-medium rounded transition-colors ${!showFightOnly
                         ? 'bg-surface-600 text-white'
                         : 'text-surface-400 hover:text-white'
                         }`}
@@ -1197,7 +1199,7 @@ function TradePageContent() {
                     </button>
                     <button
                       onClick={() => setShowFightOnly(true)}
-                      className={`px-3 py-1.5 text-xs font-medium rounded transition-colors ${showFightOnly
+                      className={`px-2 sm:px-3 py-1 sm:py-1.5 text-[10px] sm:text-xs font-medium rounded transition-colors ${showFightOnly
                         ? 'bg-primary-500 text-white'
                         : 'text-surface-400 hover:text-white'
                         }`}
@@ -1947,6 +1949,58 @@ function TradePageContent() {
                 </button>
               </div>
 
+              {/* Fight Stake Limit Info - collapsible accordion */}
+              {inFight && stake !== null && (
+                <div className="mb-3 xl:mb-4 bg-surface-800 rounded border-surface-700 overflow-hidden">
+                  <button
+                    onClick={() => setShowFightCapital(!showFightCapital)}
+                    className="w-full flex items-center justify-between p-2 xl:p-3 hover:bg-surface-700/50 transition-colors"
+                  >
+                    <span className="text-[10px] xl:text-xs text-surface-300 font-semibold uppercase">Fight Capital</span>
+                    <div className="flex items-center gap-2">
+                      <span className={`text-[10px] xl:text-xs font-mono font-semibold ${(availableStake || 0) > 0 ? 'text-win-400' : 'text-loss-400'}`}>
+                        ${(availableStake || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                      </span>
+                      <svg className={`w-3 h-3 text-surface-400 transition-transform ${showFightCapital ? 'rotate-180' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
+                    </div>
+                  </button>
+                  {showFightCapital && (
+                    <div className="px-2 xl:px-3 pb-2 xl:pb-3 space-y-1 xl:space-y-1.5 text-[10px] xl:text-xs">
+                      <div className="flex justify-between">
+                        <span className="text-surface-400">Fight Stake</span>
+                        <span className="text-white font-mono">${stake.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-surface-400">Current Positions</span>
+                        <span className="text-surface-300 font-mono">${(currentExposure || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-surface-400">Max Capital Used</span>
+                        <span className="text-surface-300 font-mono">${(maxExposureUsed || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-surface-400">Available to Trade</span>
+                        <span className={`font-mono font-semibold ${(availableStake || 0) > 0 ? 'text-win-400' : 'text-loss-400'}`}>
+                          ${(availableStake || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                        </span>
+                      </div>
+                      <div className="mt-1.5 xl:mt-2">
+                        <div className="h-1.5 xl:h-2 bg-surface-700 rounded overflow-hidden">
+                          <div
+                            className="h-full bg-surface-500 transition-all duration-300"
+                            style={{ width: `${Math.min(100, ((maxExposureUsed || 0) / stake) * 100)}%` }}
+                          />
+                        </div>
+                        <div className="flex justify-between text-[10px] xl:text-xs text-surface-500 mt-1">
+                          <span>{((maxExposureUsed || 0) / stake * 100).toFixed(0)}% used</span>
+                          <span>{(100 - (maxExposureUsed || 0) / stake * 100).toFixed(0)}% available</span>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
               {/* Leverage Slider */}
               <div className="mb-3 xl:mb-4">
                 <div className="flex justify-between items-center mb-1.5 xl:mb-2">
@@ -2646,46 +2700,6 @@ function TradePageContent() {
                   </div>
                 );
               })()}
-
-              {/* Fight Stake Limit Info - shown when in active fight */}
-              {inFight && stake !== null && (
-                <div className="mt-3 xl:mt-4 p-2 xl:p-3 bg-surface-800 rounded border-surface-700">
-                  <div className="text-[10px] xl:text-xs text-surface-300 font-semibold mb-1.5 xl:mb-2 uppercase">Fight Capital Limit</div>
-                  <div className="space-y-1 xl:space-y-1.5 text-[10px] xl:text-xs">
-                    <div className="flex justify-between">
-                      <span className="text-surface-400">Fight Stake</span>
-                      <span className="text-white font-mono">${stake.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-surface-400">Current Positions</span>
-                      <span className="text-surface-300 font-mono">${(currentExposure || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-surface-400">Max Capital Used</span>
-                      <span className="text-surface-300 font-mono">${(maxExposureUsed || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-surface-400">Available to Trade</span>
-                      <span className={`font-mono font-semibold ${(availableStake || 0) > 0 ? 'text-win-400' : 'text-loss-400'}`}>
-                        ${(availableStake || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-                      </span>
-                    </div>
-                    {/* Progress bar - shows max capital used (not current, since max never decreases) */}
-                    <div className="mt-1.5 xl:mt-2">
-                      <div className="h-1.5 xl:h-2 bg-surface-700 rounded overflow-hidden">
-                        <div
-                          className="h-full bg-surface-500 transition-all duration-300"
-                          style={{ width: `${Math.min(100, ((maxExposureUsed || 0) / stake) * 100)}%` }}
-                        />
-                      </div>
-                      <div className="flex justify-between text-[10px] xl:text-xs text-surface-500 mt-1">
-                        <span>{((maxExposureUsed || 0) / stake * 100).toFixed(0)}% used</span>
-                        <span>{(100 - (maxExposureUsed || 0) / stake * 100).toFixed(0)}% available</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
 
               {/* Challenge CTA */}
               <div className="mt-3 xl:mt-4 pt-3 xl:pt-4 border-t border-surface-800">

--- a/apps/web/src/components/FightBanner.tsx
+++ b/apps/web/src/components/FightBanner.tsx
@@ -117,44 +117,37 @@ export function FightBanner() {
         />
       </div>
       <div className="relative max-w-screen-2xl mx-auto px-2 sm:px-4">
-        {/* Mobile: 2 rows — You (left) | Timer | Opp (right) */}
-        <div className="sm:hidden py-1.5">
-          {/* Row 1: You PnL + Timer + Opp PnL */}
-          <div className="flex items-center justify-between mb-1">
-            <div className="flex items-center gap-2">
-              <div className={`w-1.5 h-1.5 rounded-full ${isConnected ? 'bg-green-500' : 'bg-surface-500'}`} />
-              <span className="text-[10px] text-surface-500">You</span>
-              <span className={`font-mono text-xs font-semibold tabular-nums ${myPnl >= 0 ? 'text-win-400' : 'text-loss-400'}`}>
-                {formatPnl(myPnl)}
-              </span>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className={`font-mono text-sm font-semibold tabular-nums ${isLowTime ? 'text-loss-500' : 'text-zinc-100'}`}>
-                {timeRemaining !== null ? formatTime(timeRemaining) : '--:--'}
-              </span>
-              <div className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
-                isWinning
-                  ? 'bg-win-500/10 text-win-500'
-                  : isLosing
-                    ? 'bg-loss-500/10 text-loss-500'
-                    : 'bg-surface-700 text-surface-400'
-              }`}>
-                {isWinning ? 'Ahead' : isLosing ? 'Behind' : 'Tied'}
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className={`font-mono text-xs font-semibold tabular-nums ${opponentPnl >= 0 ? 'text-win-400' : 'text-loss-400'}`}>
-                {formatPnl(opponentPnl)}
-              </span>
-              <span className="text-[10px] text-surface-500">{opponent.user?.handle || 'Opp'}</span>
-            </div>
+        {/* Mobile: single row — You PnL | Timer | Status | Opp PnL */}
+        <div className="sm:hidden flex items-center justify-between h-8 gap-1">
+          {/* Left: connection dot + You PnL */}
+          <div className="flex items-center gap-1 min-w-0">
+            <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${isConnected ? 'bg-green-500' : 'bg-surface-500'}`} />
+            <span className="text-[10px] text-surface-500">You</span>
+            <span className={`font-mono text-[11px] font-semibold tabular-nums ${myPnl >= 0 ? 'text-win-400' : 'text-loss-400'}`}>
+              {formatPnl(myPnl)}
+            </span>
           </div>
-          {/* Row 2: Stake + Warnings */}
-          <div className="flex items-center justify-center gap-3 text-[10px]">
-            <span className="text-surface-500">${maxSize.toLocaleString()} stake</span>
-            {hasOpenPositions && (
-              <span className="text-amber-500 animate-pulse">{fightPositions.length} Open</span>
-            )}
+          {/* Center: Timer + Status badge */}
+          <div className="flex items-center gap-1.5 shrink-0">
+            <div className={`px-1 py-0.5 rounded text-[9px] font-medium ${
+              isWinning
+                ? 'bg-win-500/10 text-win-500'
+                : isLosing
+                  ? 'bg-loss-500/10 text-loss-500'
+                  : 'bg-surface-700 text-surface-400'
+            }`}>
+              {isWinning ? 'Ahead' : isLosing ? 'Behind' : 'Tied'}
+            </div>
+            <span className={`font-mono text-[11px] font-semibold tabular-nums ${isLowTime ? 'text-loss-500' : 'text-zinc-100'}`}>
+              {timeRemaining !== null ? formatTime(timeRemaining) : '--:--'}
+            </span>
+          </div>
+          {/* Right: Opp PnL + truncated handle */}
+          <div className="flex items-center gap-1 min-w-0 justify-end">
+            <span className={`font-mono text-[11px] font-semibold tabular-nums ${opponentPnl >= 0 ? 'text-win-400' : 'text-loss-400'}`}>
+              {formatPnl(opponentPnl)}
+            </span>
+            <span className="text-[10px] text-surface-500 truncate max-w-[48px]">{opponent.user?.handle || 'Opp'}</span>
           </div>
         </div>
 

--- a/apps/web/src/lib/server/feature-flags.ts
+++ b/apps/web/src/lib/server/feature-flags.ts
@@ -55,7 +55,7 @@ export function isWalletAllowed(walletAddress: string): boolean {
  */
 export const StakeLimits = {
   maxPerUser: () => parseFloat(process.env.MAX_STAKE_PER_USER_USDC || '1000'),
-  maxPerFight: () => parseFloat(process.env.MAX_STAKE_PER_FIGHT_USDC || '500'),
+  maxPerFight: () => parseFloat(process.env.MAX_STAKE_PER_FIGHT_USDC || '5000'),
 };
 
 /**


### PR DESCRIPTION
…al accordion

- Leaderboard: match mobile font sizes to referrals/rewards pages
- FightBanner: compact single-row mobile layout for 320px screens
- Trade tabs: fix "Fight Only" toggle pushing tabs on mobile
- Fight Capital: collapsible accordion moved above leverage, open by default
- Raise max stake per fight default from $500 to $5000